### PR TITLE
Adds publishing of docker image to repo registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/naturalgis/seis-lab-data
 
       - name: "check generated docker metadata"
         run: env | grep DOCKER_METADATA_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
             GIT_COMMIT="${{ github.sha }}"
           push: false
           load: true
+          file: docker/Dockerfile
           tags: |
             ${{ steps.docker_metadata.outputs.tags }}
           labels: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
       # note - this does not run the end-to-end tests
       - name: "Run tests"
         run: |
-          docker run --rm -ti --entrypoint bash \
+          docker run --rm --entrypoint bash \
           ${{ fromJSON(steps.docker_metadata.outputs.json).tags[0] }} -c \
           uv sync --locked --group dev && uv run pytest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,11 +82,18 @@ jobs:
           ${{ fromJSON(steps.docker_metadata.outputs.json).tags[0] }} -c \
           "uv sync --locked --group dev && uv run pytest"
 
-#      - name: "Login to container registry"
-#        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}
-#        uses: docker/login-action@v3
-#        with:
-#          registry: ghcr.io
-#          username: ${{ secrets.USER_FOR_REGISTRY }}
-#          password: ${{ secrets.PAT_FOR_REGISTRY }}
-#
+      - name: "Login to container registry"
+        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Push docker image to registry"
+        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            ${{ steps.docker_metadata.outputs.tags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,6 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha
 
       - name: "check generated docker metadata"
         run: |
@@ -67,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            GIT_COMMIT=${{ fromJSON(steps.docker_metadata.outputs.json).tags.pop() }}
+            GIT_COMMIT="${{ github.sha }}"
           push: false
           tags: |
             ${{ steps.docker_metadata.outputs.tags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         run: |
           docker run --rm --entrypoint bash \
           ${{ fromJSON(steps.docker_metadata.outputs.json).tags[0] }} -c \
-          uv sync --locked --group dev && uv run pytest
+          "uv sync --locked --group dev && uv run pytest"
 
 #      - name: "Login to container registry"
 #        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,21 @@ jobs:
 #      - name: "Run tests"
 #        run: uv run pytest
 #
+
+      - name: "Determine docker-related metadata"
+        id: docker_metadata
+        uses: docker/metadata-action@v5.7.0
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{raw}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: "check generated docker metadata"
+        run: env | grep DOCKER_METADATA_OUTPUT
+
 #      - name: "Login to container registry"
 #        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}
 #        uses: docker/login-action@v3
@@ -56,13 +71,15 @@ jobs:
 #      - name: "Setup docker buildx"
 #        uses: docker/setup-buildx-action@v3
 #
-#      # TODO: build the image, then run e2e tests and then publish
-#      - name: "Build and push docker image"
+##      # TODO: build the image, then run e2e tests and then publish
+#      - name: "Build docker image"
 #        uses: docker/build-push-action@v6
 #        with:
 #          build-args: |
 #            GIT_COMMIT=${{}}
-#          labels: |
-#            org.opencontainers.image.source=https://github.com/${{}}/${{}}
+#          push: ${{ github.event_name != 'pull_request' }}
 #          tags: |
-#            ${{}}/${{}}
+#            ${{ steps.docker_metadata.outputs.tags }}
+#          labels: |
+#            ${{ steps.docker_metadata.outputs.labels }}
+#            org.opencontainers.image.source=https://github.com/${{}}/${{}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,11 +56,15 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.source=https://github.com/naturalgis/seis-lab-data
+#          labels: |
+#            org.opencontainers.image.source=https://github.com/naturalgis/seis-lab-data
 
       - name: "check generated docker metadata"
-        run: env | grep DOCKER_METADATA_OUTPUT
+        run: |
+          env | grep DOCKER_METADATA_OUTPUT
+          echo 'OUTPUT LABELS = ${{ steps.docker_metadata.outputs.labels }}'
+          echo 'OUTPUT TAGS = ${{ steps.docker_metadata.outputs.tags }}'
+          echo 'OUTPUT ANNOTATIONS = ${{ steps.docker_metadata.outputs.annotations}}'
 
 #      - name: "Login to container registry"
 #        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,8 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: "check generated docker metadata"
         run: env | grep DOCKER_METADATA_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,7 @@ jobs:
           build-args: |
             GIT_COMMIT="${{ github.sha }}"
           push: false
+          load: true
           tags: |
             ${{ steps.docker_metadata.outputs.tags }}
           labels: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,6 @@ jobs:
       - name: "Run ruff formatter"
         run: uv run ruff format --check
 
-#      # note - this does not run the end-to-end tests
-#      - name: "Run tests"
-#        run: uv run pytest
-#
-
       - name: "Determine docker-related metadata"
         id: docker_metadata
         uses: docker/metadata-action@v5.7.0
@@ -56,8 +51,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
-#          labels: |
-#            org.opencontainers.image.source=https://github.com/naturalgis/seis-lab-data
+            type=sha
 
       - name: "check generated docker metadata"
         run: |
@@ -65,6 +59,27 @@ jobs:
           echo 'OUTPUT LABELS = ${{ steps.docker_metadata.outputs.labels }}'
           echo 'OUTPUT TAGS = ${{ steps.docker_metadata.outputs.tags }}'
           echo 'OUTPUT ANNOTATIONS = ${{ steps.docker_metadata.outputs.annotations}}'
+
+      - name: "Setup docker buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build docker image"
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            GIT_COMMIT=${{ fromJSON(steps.docker_metadata.outputs.json).tags.pop() }}
+          push: false
+          tags: |
+            ${{ steps.docker_metadata.outputs.tags }}
+          labels: |
+            ${{ steps.docker_metadata.outputs.labels }}
+
+      # note - this does not run the end-to-end tests
+      - name: "Run tests"
+        run: |
+          docker run --rm -ti --entrypoint bash \
+          ${{ fromJSON(steps.docker_metadata.outputs.json).tags[0] }} -c \
+          uv sync --locked --group dev && uv run pytest
 
 #      - name: "Login to container registry"
 #        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}
@@ -74,18 +89,3 @@ jobs:
 #          username: ${{ secrets.USER_FOR_REGISTRY }}
 #          password: ${{ secrets.PAT_FOR_REGISTRY }}
 #
-#      - name: "Setup docker buildx"
-#        uses: docker/setup-buildx-action@v3
-#
-##      # TODO: build the image, then run e2e tests and then publish
-#      - name: "Build docker image"
-#        uses: docker/build-push-action@v6
-#        with:
-#          build-args: |
-#            GIT_COMMIT=${{}}
-#          push: ${{ github.event_name != 'pull_request' }}
-#          tags: |
-#            ${{ steps.docker_metadata.outputs.tags }}
-#          labels: |
-#            ${{ steps.docker_metadata.outputs.labels }}
-#            org.opencontainers.image.source=https://github.com/${{}}/${{}}


### PR DESCRIPTION
This PR adds further steps in the CI workflow to publish a docker image of the code onto our registry.

The new workflow steps build the docker image, then run the tests inside it and finally publish it in the repo registry, if appropriate.

---

- fixes #25 