### PR TITLE
Added running e2e tests in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,12 +75,25 @@ jobs:
           labels: |
             ${{ steps.docker_metadata.outputs.labels }}
 
-      # note - this does not run the end-to-end tests
       - name: "Run tests"
         run: |
           docker run --rm --entrypoint bash \
           ${{ fromJSON(steps.docker_metadata.outputs.json).tags[0] }} -c \
           "uv sync --locked --group dev && uv run pytest"
+
+      - name: "Stand up compose stack"
+        run: |
+          IMAGE_URL=${{ fromJSON(steps.docker_metadata.outputs.json).tags[0] }} \
+          docker compose --file docker/compose.ci.yaml up --detach
+
+      - name: "Run end to end tests"
+        run: |
+          docker compose --file docker/compose.ci.yaml run --rm end-to-end-tester
+
+      - name: "Stand down compose stack"
+        run: |
+          IMAGE_TAG=${{ fromJSON(steps.docker_metadata.outputs.json).tags[0] }} \
+          docker compose --file docker/compose.ci.yaml down
 
       - name: "Login to container registry"
         if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}

--- a/.woodpecker/test-deployment.yaml
+++ b/.woodpecker/test-deployment.yaml
@@ -2,12 +2,6 @@ when:
   - event: deployment
 
 steps:
-  - name: greet
-    image: ubuntu:24.04
-    commands: |
-      echo "Hello World, I would be running as the actual deployment but instead I'm here to show the current env"
-      env
-
   - name: extract-deployment-payload
     image: leplusorg/json:sha-0b8b943
     commands: |
@@ -36,7 +30,7 @@ steps:
       echo "=== Checking Prerequisites ==="
       . envvars
       export IMAGE_URL=$${IMAGE_URL}
-      
+
       if [ "$${SKIP_DEPLOYMENT}" = "true" ]; then
         echo "Skipping deployment - no image URL in deployment payload"
         exit 0
@@ -45,20 +39,20 @@ steps:
         echo "Skipping deployment - DEPLOY_ENVIRONMENT variable does not match expected value"
         exit 0
       fi
-      
+
       echo "=== Deploying Application ==="
       apk add --no-cache git
       echo "Cloning repository..."
       git clone https://github.com/NaturalGIS/seis-lab-data.git /tmp/repo
       cd /tmp/repo
       git checkout ${CI_COMMIT_SHA}
-      
+
       # Get target user/group from host directory - assumes directory already owned by correct user
       TARGET_UID=$(stat -c '%u' /opt/seis-lab-data)
       TARGET_GID=$(stat -c '%g' /opt/seis-lab-data)
-      
+
       echo "Target directory ownership: UID=$TARGET_UID, GID=$TARGET_GID"
-      
+
       COMPOSE_FILE_NAME="compose.test-env.yaml"
       LOG_FILE_NAME="dev-log-config.yml"
       ENV_FILE_NAME="compose-deployment.env"
@@ -79,7 +73,7 @@ steps:
       cd $${DEPLOYMENT_DIR}
       echo "Files in deployment directory:"
       ls -la
-      
+
       echo "Logging in to docker registry"
       echo $${GITHUB_PAT} | docker login ghcr.io --username $${GITHUB_USER} --password-stdin
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ Marine data catalog for internal usage at [IPMA]
     http://localhost:8888
 
 
+## Running tests
+
+Normal tests can be run from inside the `webapp` compose container, after installing the required dependencies:
+
+```shell
+docker compose --file docker/compose.dev.yaml exec webapp uv sync --locked --group dev
+docker compose --file docker/compose.dev.yaml exec webapp uv run pytest
+```
+
+End to end tests can be run with the `end-to-end-tester` compose service, by issuing a one-off run:
+
+```shell
+docker compose --file docker/compose.dev.yaml run --rm end-to-end-tester
+```
+
+
 [docker]: https://www.docker.com/
 [IPMA]: https://www.ipma.pt/pt/index.html
 [pre-commit]: https://pre-commit.com/

--- a/docker/compose.ci.yaml
+++ b/docker/compose.ci.yaml
@@ -1,0 +1,50 @@
+x-common-image: &common-image "${IMAGE_URL}"
+
+x-common-env: &common-env
+  SEIS_LAB_DATA__DEBUG: true
+  SEIS_LAB_DATA__MESSAGE_BROKER_DSN: redis://message-broker:6379
+
+services:
+
+  message-broker:
+    image: redis:8
+    ports:
+      - target: 6379
+        published: 6379
+    healthcheck:
+      test: "[ redis-cli PING ] = 'PONG'"
+
+  webapp:
+    image: *common-image
+    environment:
+      <<: *common-env
+      SEIS_LAB_DATA__BIND_HOST: 0.0.0.0
+      SEIS_LAB_DATA__BIND_PORT: 5000
+      SEIS_LAB_DATA__PUBLIC_URL: http://localhost:8888
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sld-router.rule=PathRegexp(`^/`)"
+      - "traefik.http.routers.sld-router.entrypoints=web"
+      - "traefik.http.services.sld-service.loadbalancer.server.port=5000"
+
+  processing-worker:
+    image: *common-image
+    command:
+      - "run-processing-worker"
+    environment:
+      <<: *common-env
+
+  end-to-end-tester:
+    image: mcr.microsoft.com/playwright/python:v1.53.0-noble
+    profiles:
+      - "e2e-test"
+    volumes:
+      - type: bind
+        source: $PWD/tests/e2e
+        target: /tests/e2e
+        read_only: true
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        pip install "playwright==1.53.0" pytest-playwright
+        pytest --base-url=http://webapp:5000 /tests

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -73,6 +73,21 @@ services:
     volumes:
       *common-volumes
 
+  end-to-end-tester:
+    image: mcr.microsoft.com/playwright/python:v1.53.0-noble
+    profiles:
+      - "e2e-test"
+    volumes:
+      - type: bind
+        source: $PWD/tests/e2e
+        target: /tests/e2e
+        read_only: true
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        pip install "playwright==1.53.0" pytest-playwright
+        pytest --base-url=http://webapp:5000 /tests
+
   jupyter:
     image: *common-image
     environment:

--- a/tests/e2e/test_e2e_webapp_home.py
+++ b/tests/e2e/test_e2e_webapp_home.py
@@ -1,0 +1,14 @@
+import pytest
+from playwright.sync_api import (
+    Page,
+    expect,
+)
+
+
+@pytest.mark.e2e
+def test_webapp_home_is_up(page: Page):
+    page.goto("/")
+    # NOTE: the below is a bad example of how to use playwright locators
+    # this is intended just as an initial placeholder test though
+    locator = page.locator("body > div.container > div.row > p")
+    expect(locator).to_have_text("Hello, world!")

--- a/tests/test_webapp_home.py
+++ b/tests/test_webapp_home.py
@@ -1,11 +1,4 @@
-import pytest
-from playwright.sync_api import (
-    Page,
-    expect,
-)
 from starlette.testclient import TestClient
-
-from seis_lab_data.config import SeisLabDataSettings
 
 
 def test_home_contains_message(test_client: TestClient):
@@ -13,12 +6,3 @@ def test_home_contains_message(test_client: TestClient):
     assert response.status_code == 200
     target_message = "Hello, world!"
     assert target_message in response.text
-
-
-@pytest.mark.e2e
-def test_webapp_home_is_up(settings: SeisLabDataSettings, page: Page):
-    page.goto("/")
-    # NOTE: the below is a bad example of how to use playwright locators
-    # this is intended just as an initial placeholder test though
-    locator = page.locator("body > div.container > div.row > p")
-    expect(locator).to_have_text("Hello, world!")


### PR DESCRIPTION
This PR adds a compose file suitable for running in CI which enables running end to end tests.

Implementation relies on using an extra `end-to-end-tester` service, which uses the official [playwright](https://playwright.dev/python/) docker image and has e2e tests mounted inside. This service is part of a compose 'e2e-test' [profile](https://docs.docker.com/reference/compose-file/services/#profiles), and is therefore skipped when starting up the stack, but can be ran on demand.

---

- fixes #24