### PR TITLE
Integrate dramatiq

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,19 +37,19 @@ EXPOSE 5000
 RUN --mount=type=cache,uid=1000,gid=1000,target=/home/appuser/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project
+    uv sync --locked --no-install-project --compile-bytecode
 
 # Copy project into the image
 COPY --chown=appuser:appuser . .
 
 # Sync the project
 RUN --mount=type=cache,uid=1000,gid=1000,target=/home/appuser/.cache/uv \
-    uv sync --locked
+    uv sync --locked --compile-bytecode
 
 # Compile translations
-RUN uv run seis-lab-data translations compile
+RUN uv run --no-sync --locked seis-lab-data translations compile
 
 # use tini as the init process
-ENTRYPOINT ["tini", "-g", "--", "uv", "run", "seis-lab-data"]
+ENTRYPOINT ["tini", "-g", "--", "uv", "run", "--no-sync", "--locked", "seis-lab-data"]
 
 CMD ["run-web-server"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 requires-python = ">=3.13"
 dependencies = [
     "authlib>=1.6.1",
+    "dramatiq[redis,watch]>=1.18.0",
     "httpx>=0.28.1",
     "itsdangerous>=2.2.0",
     "jinja2>=3.1.6",

--- a/src/seis_lab_data/main.py
+++ b/src/seis_lab_data/main.py
@@ -55,7 +55,6 @@ def run_processing_worker(ctx: typer.Context) -> None:
             [
                 "--processes=1",
                 "--threads=1",
-                "--verbose",
                 f"--watch={Path(__file__).parent}",
                 "--watch-exclude=__pycache__/*",
             ]

--- a/src/seis_lab_data/main.py
+++ b/src/seis_lab_data/main.py
@@ -1,17 +1,14 @@
-import functools
 import logging
 import os
 import sys
 from pathlib import Path
 
-import redis
 from rich.padding import Padding
 from rich.panel import Panel
 import typer
 
 from . import config
 from .translations_app import app as translations_app
-from .processing.main import message_handler
 
 logger = logging.getLogger(__name__)
 app = typer.Typer()
@@ -33,7 +30,9 @@ def greet(ctx: typer.Context) -> None:
     context.status_console.print("Hello from seis-lab-data")
 
 
-@app.command()
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
 def run_processing_worker(ctx: typer.Context) -> None:
     """Start a processing worker."""
     context: config.SeisLabDataCliContext = ctx.obj
@@ -45,17 +44,28 @@ def run_processing_worker(ctx: typer.Context) -> None:
         style="green",
     )
     context.status_console.print(Padding(panel, 1))
-    connection = redis.Redis.from_url(
-        context.settings.message_broker_dsn.unicode_string(), decode_responses=True
+    dramatiq_args = [
+        "dramatiq",
+        # f"{Path(__file__).parent / 'processing/broker:get_broker'}",
+        "seis_lab_data.processing.broker:setup_broker",
+        "seis_lab_data.processing.tasks",
+    ]
+    if context.settings.debug:
+        dramatiq_args.extend(
+            [
+                "--processes=1",
+                "--threads=1",
+                "--verbose",
+                f"--watch={Path(__file__).parent}",
+                "--watch-exclude=__pycache__/*",
+            ]
+        )
+    sys.stdout.flush()
+    sys.stderr.flush()
+    context.status_console.print(
+        f"Starting dramatiq worker with args: {dramatiq_args=}"
     )
-    pubsub = connection.pubsub()
-    handler = functools.partial(message_handler, context=context)
-    for channel_pattern in context.settings.message_broker_channels:
-        pubsub.subscribe(**{channel_pattern: handler})
-    while True:
-        message = pubsub.get_message()
-        if message is not None:
-            context.status_console.print(f"Caught unhandled message: {message}")
+    os.execvp("dramatiq", dramatiq_args)
 
 
 @app.command()

--- a/src/seis_lab_data/processing/broker.py
+++ b/src/seis_lab_data/processing/broker.py
@@ -5,13 +5,42 @@ from dramatiq.brokers.redis import RedisBroker
 
 from .. import config
 
+# This import is needed - DO NOT REMOVE
+# Dramatiq's @actor decorator tries to eagerly connect to the global dramatiq broker
+# and this does not play well with using a factory pattern to create the worker,
+# as it means the worker is not available at import time yet.
+# The following import is part of a workaround that uses the dramatiq StubBroker
+# as the initial broker where actors are registered and then changes to a real
+# broker by calling the `setup_broker()` function, as defined in this module.
+# This import of the tasks module causes existing actors to be discovered and
+# registered with dramatiq (using the stub broker). When calling the `dramatiq` cli,
+# we rely on this import being done before the call to our own `setup_broker()` function,
+# as we need to ensure the actors are known before we set the real broker.
+from ..processing import tasks  # noqa
+
 logger = logging.getLogger(__name__)
 
 
 def setup_broker(settings: config.SeisLabDataSettings | None = None) -> None:
+    """Setup the dramatiq message broker.
+
+    This function relies on all actors having already been imported and registered into
+    a global dramatiq stub broker. It works by inspecting this previous broker, gathering
+    existing actors from it and then re-registering them with the real broker, which it
+    also creates and sets as the global broker for dramatiq.
+
+    This is part of a workaround that enables using dramatiq together with a factory
+    pattern. It is not very pretty, but it works.
+    """
     settings = settings or config.get_settings()
-    broker = RedisBroker(
+    new_broker = RedisBroker(
         host=settings.message_broker_dsn.host,
         port=settings.message_broker_dsn.port,
     )
-    dramatiq.set_broker(broker)
+    old_broker = dramatiq.get_broker()
+    # reconfigure actors to use the new broker
+    for existing_actor_name in old_broker.get_declared_actors():
+        actor = old_broker.get_actor(existing_actor_name)
+        actor.broker = new_broker
+        new_broker.declare_actor(actor)
+    dramatiq.set_broker(new_broker)

--- a/src/seis_lab_data/processing/broker.py
+++ b/src/seis_lab_data/processing/broker.py
@@ -16,7 +16,7 @@ from .. import config
 # registered with dramatiq (using the stub broker). When calling the `dramatiq` cli,
 # we rely on this import being done before the call to our own `setup_broker()` function,
 # as we need to ensure the actors are known before we set the real broker.
-from ..processing import tasks  # noqa
+from . import tasks  # noqa
 
 logger = logging.getLogger(__name__)
 

--- a/src/seis_lab_data/processing/broker.py
+++ b/src/seis_lab_data/processing/broker.py
@@ -1,0 +1,17 @@
+import logging
+
+import dramatiq
+from dramatiq.brokers.redis import RedisBroker
+
+from .. import config
+
+logger = logging.getLogger(__name__)
+
+
+def setup_broker(settings: config.SeisLabDataSettings | None = None) -> None:
+    settings = settings or config.get_settings()
+    broker = RedisBroker(
+        host=settings.message_broker_dsn.host,
+        port=settings.message_broker_dsn.port,
+    )
+    dramatiq.set_broker(broker)

--- a/src/seis_lab_data/processing/broker.py
+++ b/src/seis_lab_data/processing/broker.py
@@ -33,14 +33,17 @@ def setup_broker(settings: config.SeisLabDataSettings | None = None) -> None:
     pattern. It is not very pretty, but it works.
     """
     settings = settings or config.get_settings()
-    new_broker = RedisBroker(
-        host=settings.message_broker_dsn.host,
-        port=settings.message_broker_dsn.port,
-    )
-    old_broker = dramatiq.get_broker()
-    # reconfigure actors to use the new broker
-    for existing_actor_name in old_broker.get_declared_actors():
-        actor = old_broker.get_actor(existing_actor_name)
-        actor.broker = new_broker
-        new_broker.declare_actor(actor)
-    dramatiq.set_broker(new_broker)
+    if settings.message_broker_dsn is not None:
+        new_broker = RedisBroker(
+            host=settings.message_broker_dsn.host,
+            port=settings.message_broker_dsn.port,
+        )
+        old_broker = dramatiq.get_broker()
+        # reconfigure actors to use the new broker
+        for existing_actor_name in old_broker.get_declared_actors():
+            actor = old_broker.get_actor(existing_actor_name)
+            actor.broker = new_broker
+            new_broker.declare_actor(actor)
+        dramatiq.set_broker(new_broker)
+    else:
+        logger.debug("No message broker DSN configured, skipping broker setup")

--- a/src/seis_lab_data/processing/main.py
+++ b/src/seis_lab_data/processing/main.py
@@ -1,9 +1,0 @@
-import logging
-
-from ..config import SeisLabDataCliContext
-
-logger = logging.getLogger(__name__)
-
-
-def message_handler(message: dict, *, context: SeisLabDataCliContext):
-    logger.debug(f"received message: {message}")

--- a/src/seis_lab_data/processing/tasks.py
+++ b/src/seis_lab_data/processing/tasks.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 # trying to connect to it
 _stub_broker = StubBroker()
 dramatiq.set_broker(_stub_broker)
-print("dramatiq broker set to the stub broker")
 
 
 @dramatiq.actor

--- a/src/seis_lab_data/processing/tasks.py
+++ b/src/seis_lab_data/processing/tasks.py
@@ -1,10 +1,18 @@
 import logging
 
 import dramatiq
+from dramatiq.brokers.stub import StubBroker
 
 from .. import config
 
 logger = logging.getLogger(__name__)
+
+# this _stub_broker is only meant as a way to be able to register actors
+# without triggering the unwanted side-effect of having dramatiq eagerly
+# trying to connect to it
+_stub_broker = StubBroker()
+dramatiq.set_broker(_stub_broker)
+print("dramatiq broker set to the stub broker")
 
 
 @dramatiq.actor
@@ -13,3 +21,4 @@ def process_data(message: str):
     logger.debug(
         f"Received message: {message} - Also settings.debug is {settings.debug}"
     )
+    print(f"Received message: {message} - Also settings.debug is {settings.debug}")

--- a/src/seis_lab_data/processing/tasks.py
+++ b/src/seis_lab_data/processing/tasks.py
@@ -1,0 +1,15 @@
+import logging
+
+import dramatiq
+
+from .. import config
+
+logger = logging.getLogger(__name__)
+
+
+@dramatiq.actor
+def process_data(message: str):
+    settings = config.get_settings()
+    logger.debug(
+        f"Received message: {message} - Also settings.debug is {settings.debug}"
+    )

--- a/src/seis_lab_data/webapp/app.py
+++ b/src/seis_lab_data/webapp/app.py
@@ -22,6 +22,7 @@ from ..auth import (
     AuthConfig,
     get_oauth_manager,
 )
+from ..processing.broker import setup_broker
 
 from .routes import routes
 
@@ -53,6 +54,7 @@ async def lifespan(app: Starlette) -> AsyncIterator[State]:
 
 
 def create_app_from_settings(settings: config.SeisLabDataSettings) -> Starlette:
+    setup_broker(settings)
     app = Starlette(
         debug=settings.debug,
         routes=routes,

--- a/src/seis_lab_data/webapp/routes.py
+++ b/src/seis_lab_data/webapp/routes.py
@@ -1,5 +1,7 @@
 import dataclasses
 import logging
+import uuid
+
 from starlette_babel import gettext_lazy as _
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
@@ -7,6 +9,7 @@ from starlette.routing import Route
 
 from ..config import SeisLabDataSettings
 from ..constants import AUTH_CLIENT_NAME
+from ..processing import tasks
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +37,9 @@ class User:
 
 async def home(request: Request):
     template_processor = request.state.templates
+    request_id = str(uuid.uuid4())
     logger.debug("This is the home route")
+    tasks.process_data.send(f"hi from the home route with request id {request_id}")
     return template_processor.TemplateResponse(
         request, "index.html", context={"greeting": _("Hi there!")}
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from seis_lab_data.webapp.app import create_app_from_settings
 @pytest.fixture
 def settings():
     original_settings = seis_lab_data.config.get_settings()
+    original_settings.message_broker_dsn = None
     return original_settings
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -328,6 +328,27 @@ wheels = [
 ]
 
 [[package]]
+name = "dramatiq"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9f/c8be928a88c387ed27344de089278e76d893dc71ad9e4b2a39a61deab0d8/dramatiq-1.18.0.tar.gz", hash = "sha256:5ea436b6e50dae64d4de04f1eb519ad239a6b1ba6315ba1dce1c0c4c1ebedfaf", size = 100868 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/00/d9ea755cdeda3d498504775b62122b72ba282b91446fd58980171fb1084c/dramatiq-1.18.0-py3-none-any.whl", hash = "sha256:d360f608aa3cd06f5db714bfcd23825dc7098bacfee52aca536b0bb0faae3c69", size = 121231 },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+watch = [
+    { name = "watchdog" },
+    { name = "watchdog-gevent" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -361,6 +382,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121 },
+]
+
+[[package]]
+name = "gevent"
+version = "25.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "greenlet", marker = "platform_python_implementation == 'CPython'" },
+    { name = "zope-event" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/58/267e8160aea00ab00acd2de97197eecfe307064a376fb5c892870a8a6159/gevent-25.5.1.tar.gz", hash = "sha256:582c948fa9a23188b890d0bc130734a506d039a2e5ad87dae276a456cc683e61", size = 6388207 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/25/2162b38d7b48e08865db6772d632bd1648136ce2bb50e340565e45607cad/gevent-25.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a022a9de9275ce0b390b7315595454258c525dc8287a03f1a6cacc5878ab7cbc", size = 2928044 },
+    { url = "https://files.pythonhosted.org/packages/1b/e0/dbd597a964ed00176da122ea759bf2a6c1504f1e9f08e185379f92dc355f/gevent-25.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fae8533f9d0ef3348a1f503edcfb531ef7a0236b57da1e24339aceb0ce52922", size = 1788751 },
+    { url = "https://files.pythonhosted.org/packages/f1/74/960cc4cf4c9c90eafbe0efc238cdf588862e8e278d0b8c0d15a0da4ed480/gevent-25.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c7b32d9c3b5294b39ea9060e20c582e49e1ec81edbfeae6cf05f8ad0829cb13d", size = 1869766 },
+    { url = "https://files.pythonhosted.org/packages/56/78/fa84b1c7db79b156929685db09a7c18c3127361dca18a09e998e98118506/gevent-25.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b95815fe44f318ebbfd733b6428b4cb18cc5e68f1c40e8501dd69cc1f42a83d", size = 1835358 },
+    { url = "https://files.pythonhosted.org/packages/00/5c/bfefe3822bbca5b83bfad256c82251b3f5be13d52d14e17a786847b9b625/gevent-25.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d316529b70d325b183b2f3f5cde958911ff7be12eb2b532b5c301f915dbbf1e", size = 2073071 },
+    { url = "https://files.pythonhosted.org/packages/20/e4/08a77a3839a37db96393dea952e992d5846a881b887986dde62ead6b48a1/gevent-25.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f6ba33c13db91ffdbb489a4f3d177a261ea1843923e1d68a5636c53fe98fa5ce", size = 1809805 },
+    { url = "https://files.pythonhosted.org/packages/2b/ac/28848348f790c1283df74b0fc0a554271d0606676470f848eccf84eae42a/gevent-25.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37ee34b77c7553777c0b8379915f75934c3f9c8cd32f7cd098ea43c9323c2276", size = 2138305 },
+    { url = "https://files.pythonhosted.org/packages/52/9e/0e9e40facd2d714bfb00f71fc6dacaacc82c24c1c2e097bf6461e00dec9f/gevent-25.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fa6aa0da224ed807d3b76cdb4ee8b54d4d4d5e018aed2478098e685baae7896", size = 1637444 },
+    { url = "https://files.pythonhosted.org/packages/60/16/b71171e97ec7b4ded8669542f4369d88d5a289e2704efbbde51e858e062a/gevent-25.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:0bacf89a65489d26c7087669af89938d5bfd9f7afb12a07b57855b9fad6ccbd0", size = 2937113 },
 ]
 
 [[package]]
@@ -1539,6 +1583,7 @@ name = "seis-lab-data"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "dramatiq", extra = ["redis", "watch"] },
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "jinja2" },
@@ -1568,6 +1613,7 @@ jupyter = [
 [package.metadata]
 requires-dist = [
     { name = "authlib", specifier = ">=1.6.1" },
+    { name = "dramatiq", extras = ["redis", "watch"], specifier = ">=1.18.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -1865,6 +1911,40 @@ wheels = [
 ]
 
 [[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480 },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451 },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057 },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
+name = "watchdog-gevent"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gevent" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/69/91cfca7c21c382e3a8aca4251dcd7d4315228d9346381feb2dde36d14061/watchdog_gevent-0.2.1.tar.gz", hash = "sha256:ae6b94d0f8c8ce1c5956cd865f612b61f456cf19801744bba25a349fe8e8c337", size = 4296 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/a9/54b88e150b77791958957e2188312477d09fc84820fc03f8b3a7569d10b0/watchdog_gevent-0.2.1-py3-none-any.whl", hash = "sha256:e8114658104a018f626ee54052335407c1438369febc776c4b4c4308ed002350", size = 3462 },
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1972,4 +2052,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
+]
+
+[[package]]
+name = "zope-event"
+version = "5.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/9f/c443569a68d3844c044d9fa9711e08adb33649b527b4d432433f4c2a6a02/zope_event-5.1.1.tar.gz", hash = "sha256:c1ac931abf57efba71a2a313c5f4d57768a19b15c37e3f02f50eb1536be12d4e", size = 18811 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/04/fd55695f6448abd22295fc68b2d3a135389558f0f49a24b0dffe019d0ecb/zope_event-5.1.1-py3-none-any.whl", hash = "sha256:8d5ea7b992c42ce73a6fa9c2ba99a004c52cd9f05d87f3220768ef0329b92df7", size = 7014 },
+]
+
+[[package]]
+name = "zope-interface"
+version = "7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/93/9210e7606be57a2dfc6277ac97dcc864fd8d39f142ca194fdc186d596fda/zope.interface-7.2.tar.gz", hash = "sha256:8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe", size = 252960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3b/e309d731712c1a1866d61b5356a069dd44e5b01e394b6cb49848fa2efbff/zope.interface-7.2-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:3e0350b51e88658d5ad126c6a57502b19d5f559f6cb0a628e3dc90442b53dd98", size = 208961 },
+    { url = "https://files.pythonhosted.org/packages/49/65/78e7cebca6be07c8fc4032bfbb123e500d60efdf7b86727bb8a071992108/zope.interface-7.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15398c000c094b8855d7d74f4fdc9e73aa02d4d0d5c775acdef98cdb1119768d", size = 209356 },
+    { url = "https://files.pythonhosted.org/packages/11/b1/627384b745310d082d29e3695db5f5a9188186676912c14b61a78bbc6afe/zope.interface-7.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:802176a9f99bd8cc276dcd3b8512808716492f6f557c11196d42e26c01a69a4c", size = 264196 },
+    { url = "https://files.pythonhosted.org/packages/b8/f6/54548df6dc73e30ac6c8a7ff1da73ac9007ba38f866397091d5a82237bd3/zope.interface-7.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb23f58a446a7f09db85eda09521a498e109f137b85fb278edb2e34841055398", size = 259237 },
+    { url = "https://files.pythonhosted.org/packages/b6/66/ac05b741c2129fdf668b85631d2268421c5cd1a9ff99be1674371139d665/zope.interface-7.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a71a5b541078d0ebe373a81a3b7e71432c61d12e660f1d67896ca62d9628045b", size = 264696 },
+    { url = "https://files.pythonhosted.org/packages/0a/2f/1bccc6f4cc882662162a1158cda1a7f616add2ffe322b28c99cb031b4ffc/zope.interface-7.2-cp313-cp313-win_amd64.whl", hash = "sha256:4893395d5dd2ba655c38ceb13014fd65667740f09fa5bb01caa1e6284e48c0cd", size = 212472 },
 ]


### PR DESCRIPTION
This PR adds [dramatiq] integration - this is to be the way that tasks get processed in the background.

The proposed implementation is not very straightforward. 
The usual way to declare an async task with dramatiq is by using its `@actor` decorator. Unfortunately this does not play well with using a factory function pattern, as the decorator has the side-effect of trying to connect to the message broker at import time - the broker is not created at import time, but rather when the factory function is called. 

There are some related issues on the dramatiq repo, for example:

- bogdanp/dramatiq#600
- bogdanp/dramatiq#163
- bogdanp/dramatiq#102

This seems to be a design decision by dramatiq, with some alternatives being seen as interesting enough to be on its cookbook, but not likely to be incorporated into dramatiq itself.

The changes in this PR employ a simpler alternative, which relies on using a `StubBroker` instance at import time, which is then swapped out by a real `RedisBroker` inside the app factory function. This method seems to work well, with the PR including a submission of a task in the landing page, which gets executed correctly

---

- fixes #52

[dramatiq]: https://dramatiq.io/index.html