### PR TITLE
Fix faulty woodpecker deployment filter

### DIFF
--- a/.woodpecker/test-deployment.yaml
+++ b/.woodpecker/test-deployment.yaml
@@ -1,6 +1,6 @@
 when:
   - event: deployment
-    evaluate: 'CI_COMMIT_AUTHOR == "github-actionsbot"'
+    evaluate: 'CI_DEPLOYMENT_CREATOR == "github-actions[bot]"'
 
 steps:
   - name: extract-deployment-payload


### PR DESCRIPTION
This PR modifies the woodpecker pipeline used for deployment in order to filter based on the value of `CI_DEPLOYMENT_CREATOR`, which ought to make our CD work again

---
- fixes #53