### PR TITLE
#114 Updated docs based on wiki

### DIFF
--- a/docs/dataset-reference.md
+++ b/docs/dataset-reference.md
@@ -1,0 +1,80 @@
+# Dataset reference
+
+Quick reference for the data model dimensions used to classify datasets in the archive.
+
+## Domain types
+
+| Code | Domain type | Description |
+|------|-------------|-------------|
+| D1 | Geophysical | Remote sensing and acoustic survey data (bathymetry, backscatter, seismic, magnetometer/gradiometer) |
+| D2 | Geotechnical | Physical sampling and in-situ testing data (superficial sediment samples, cores, CPT tests) |
+
+## Dataset categories
+
+| Code | Category | Domain |
+|------|----------|--------|
+| C1 | Bathymetry | Geophysical |
+| C2 | Backscatter | Geophysical |
+| C3 | Seismic | Geophysical |
+| C4 | Magnetometer/gradiometer | Geophysical |
+| C5 | Superficial sediment samples | Geotechnical |
+| C6 | Cores | Geotechnical |
+| C7 | CPT tests | Geotechnical |
+
+## Workflow stages
+
+| Code | Stage | Description |
+|------|-------|-------------|
+| S1 | Raw data | Unprocessed data as acquired by the instrument |
+| S2 | QC | Quality-controlled data with artefacts flagged or removed |
+| S3 | Processed data | Data processed into derived products (grids, mosaics) |
+| S4 | Interpreted data | Final products with geological or geophysical interpretation |
+
+## Format-to-category matrix
+
+Which file formats appear in which category and stage combinations. See
+[Supported formats](supported-formats.md) for detailed format descriptions.
+
+### Bathymetry (C1)
+
+| Format | Raw (S1) | QC (S2) | Processed (S3) | Interpreted (S4) |
+|--------|----------|---------|-----------------|-------------------|
+| KMALL | Primary | | | |
+| XYZ | Primary | Primary | | Secondary |
+| CSV | Primary | Primary | | Secondary |
+| NetCDF | | | Primary | Primary |
+| GeoTIFF | | | Primary | Primary |
+| CSAR | | | Primary | |
+| Float Grid (.flt) | | | Secondary | Primary/Secondary |
+| ASCII Grid (.asc) | | | | Primary |
+| HIPS Project | | | Primary | |
+| Shapefile | Secondary | Secondary | Secondary | Secondary |
+| GeoJSON | | | Secondary | Secondary |
+| GeoPackage | | | Secondary | Secondary |
+| KML/KMZ | | | | Secondary |
+| File Geodatabase | Secondary | Secondary | Secondary | Primary/Secondary |
+| XLS | Secondary | Secondary | Secondary | |
+
+### Backscatter (C2)
+
+| Format | Raw (S1) | QC (S2) | Processed (S3) | Interpreted (S4) |
+|--------|----------|---------|-----------------|-------------------|
+| KMALL | Primary | | | |
+| XYZ | Primary | | | Primary |
+| CSV | Primary | | | Primary |
+| NetCDF | | | Primary | Primary |
+| GeoTIFF | | Primary | Primary | Primary |
+| CSAR | | | Primary | |
+| Float Grid (.flt) | | | | Primary |
+| ASCII Grid (.asc) | | | | Primary |
+| GeoJSON | | | Secondary | Secondary |
+| GeoPackage | | | Secondary | Secondary |
+| KML/KMZ | | | | Secondary |
+| File Geodatabase | Secondary | Secondary | Secondary | Primary/Secondary |
+
+### Seismic (C3)
+
+| Format | Raw (S1) | QC (S2) | Processed (S3) | Interpreted (S4) |
+|--------|----------|---------|-----------------|-------------------|
+| SEG-Y | Primary | | | |
+| JSF | Primary | | | |

--- a/docs/dataset-reference.pt.md
+++ b/docs/dataset-reference.pt.md
@@ -1,0 +1,81 @@
+# Referência de dados
+
+Referência rápida para as dimensões do modelo de dados utilizadas para classificar conjuntos
+de dados no arquivo.
+
+## Tipos de domínio
+
+| Código | Tipo de domínio | Descrição |
+|--------|-----------------|-----------|
+| D1 | Geofísico | Dados de deteção remota e levantamentos acústicos (batimetria, backscatter, sísmica, magnetómetro/gradiómetro) |
+| D2 | Geotécnico | Dados de amostragem física e ensaios in-situ (amostras de sedimentos superficiais, núcleos, testes CPT) |
+
+## Categorias de dados
+
+| Código | Categoria | Domínio |
+|--------|-----------|---------|
+| C1 | Batimetria | Geofísico |
+| C2 | Backscatter | Geofísico |
+| C3 | Sísmica | Geofísico |
+| C4 | Magnetómetro/gradiómetro | Geofísico |
+| C5 | Amostras de sedimentos superficiais | Geotécnico |
+| C6 | Núcleos | Geotécnico |
+| C7 | Testes CPT | Geotécnico |
+
+## Fases do fluxo de trabalho
+
+| Código | Fase | Descrição |
+|--------|------|-----------|
+| S1 | Dados em bruto | Dados não processados tal como adquiridos pelo instrumento |
+| S2 | Controlo de qualidade | Dados com artefactos identificados ou removidos |
+| S3 | Dados processados | Dados processados em produtos derivados (grelhas, mosaicos) |
+| S4 | Dados interpretados | Produtos finais com interpretação geológica ou geofísica |
+
+## Matriz formato-categoria
+
+Indica quais formatos de ficheiro aparecem em que combinações de categoria e fase. Consulte
+[Formatos suportados](supported-formats.pt.md) para descrições detalhadas dos formatos.
+
+### Batimetria (C1)
+
+| Formato | Em bruto (S1) | CQ (S2) | Processados (S3) | Interpretados (S4) |
+|---------|---------------|---------|-------------------|---------------------|
+| KMALL | Principal | | | |
+| XYZ | Principal | Principal | | Secundário |
+| CSV | Principal | Principal | | Secundário |
+| NetCDF | | | Principal | Principal |
+| GeoTIFF | | | Principal | Principal |
+| CSAR | | | Principal | |
+| Float Grid (.flt) | | | Secundário | Principal/Secundário |
+| ASCII Grid (.asc) | | | | Principal |
+| Projeto HIPS | | | Principal | |
+| Shapefile | Secundário | Secundário | Secundário | Secundário |
+| GeoJSON | | | Secundário | Secundário |
+| GeoPackage | | | Secundário | Secundário |
+| KML/KMZ | | | | Secundário |
+| File Geodatabase | Secundário | Secundário | Secundário | Principal/Secundário |
+| XLS | Secundário | Secundário | Secundário | |
+
+### Backscatter (C2)
+
+| Formato | Em bruto (S1) | CQ (S2) | Processados (S3) | Interpretados (S4) |
+|---------|---------------|---------|-------------------|---------------------|
+| KMALL | Principal | | | |
+| XYZ | Principal | | | Principal |
+| CSV | Principal | | | Principal |
+| NetCDF | | | Principal | Principal |
+| GeoTIFF | | Principal | Principal | Principal |
+| CSAR | | | Principal | |
+| Float Grid (.flt) | | | | Principal |
+| ASCII Grid (.asc) | | | | Principal |
+| GeoJSON | | | Secundário | Secundário |
+| GeoPackage | | | Secundário | Secundário |
+| KML/KMZ | | | | Secundário |
+| File Geodatabase | Secundário | Secundário | Secundário | Principal/Secundário |
+
+### Sísmica (C3)
+
+| Formato | Em bruto (S1) | CQ (S2) | Processados (S3) | Interpretados (S4) |
+|---------|---------------|---------|-------------------|---------------------|
+| SEG-Y | Principal | | | |
+| JSF | Principal | | | |

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -72,7 +72,7 @@ products.
 | Categories | Bathymetry, Backscatter |
 | Stages | Processed data, Interpreted data |
 
-Network Common Data Form — a self-describing binary format widely used for oceanographic,
+Network Common Data Form, a self-describing binary format widely used for oceanographic,
 atmospheric, and climate data. GDAL can read NetCDF files as raster datasets, but only when
 they follow the CF (Climate and Forecast) conventions with properly defined coordinate
 variables, dimensions, and grid mapping attributes. Unstructured NetCDF files or files that
@@ -137,7 +137,7 @@ via VRT.
 | Categories | Bathymetry, Backscatter |
 | Stages | Raw data, QC, Processed data, Interpreted data |
 
-ESRI File Geodatabase — a directory containing multiple database files that store vector and
+ESRI File Geodatabase, a directory containing multiple database files that store vector and
 raster datasets. Used as secondary file for raw/QC/processed data and as primary/secondary for
 interpreted products. Read-only access via the OpenFileGDB driver (no ESRI license required).
 
@@ -266,7 +266,7 @@ Geophysical position data exchange format. Can be imported using the SeisPos_Imp
 | Stages | Processed data |
 
 CARIS HIPS and SIPS project directory. Proprietary format containing processed multibeam data.
-No automated extraction is planned — treated as an opaque directory.
+No automated extraction is planned, treated as an opaque directory.
 
 ### XLS
 

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -1,0 +1,281 @@
+# Supported file formats
+
+This page documents the file formats found in the marine data archive and their support status
+in the SeisLabData extraction pipeline.
+
+## GDAL raster formats
+
+These formats are read using GDAL raster drivers. The extractor can retrieve: bounding box,
+CRS/EPSG code, band count, pixel resolution, and nodata value.
+
+### GeoTIFF
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.tif`, `.tiff` |
+| Media type | `image/tiff` |
+| GDAL driver | GTiff |
+| Categories | Bathymetry, Backscatter |
+| Stages | QC, Processed data, Interpreted data |
+
+Georeferenced raster format with embedded CRS and metadata. Widely supported across GIS tools.
+Used as primary file for processed bathymetry/backscatter grids and interpreted products.
+
+### XYZ grid
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.xyz` |
+| Media type | `text/plain` |
+| GDAL driver | XYZ |
+| Categories | Bathymetry, Backscatter |
+| Stages | Raw data, QC, Interpreted data |
+
+Plain text point cloud format with X, Y, Z columns. Used as primary file for raw/QC bathymetry
+data and as secondary file in some stages. GDAL reads it as a gridded raster dataset.
+
+### ASCII Grid
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.asc` |
+| Media type | `text/plain` |
+| GDAL driver | AAIGrid |
+| Categories | Bathymetry, Backscatter |
+| Stages | Interpreted data |
+
+ESRI ASCII raster format. Header defines grid dimensions, cell size, origin, and nodata value,
+followed by space-delimited cell values. Used as primary file for interpreted products.
+
+### Float Grid
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.flt` + `.hdr` |
+| Media type | `application/octet-stream` |
+| GDAL driver | EHdr |
+| Categories | Bathymetry, Backscatter |
+| Stages | Processed data, Interpreted data |
+
+Binary raster format storing 32-bit IEEE floating-point values in row-major order. Requires a
+companion `.hdr` header file containing grid metadata (ncols, nrows, cellsize, nodata_value,
+byteorder). Used as secondary file for processed data and as primary/secondary for interpreted
+products.
+
+### NetCDF
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.nc`, `.nc4` |
+| Media type | `application/x-netcdf` |
+| GDAL driver | netCDF |
+| Categories | Bathymetry, Backscatter |
+| Stages | Processed data, Interpreted data |
+
+Network Common Data Form — a self-describing binary format widely used for oceanographic,
+atmospheric, and climate data. GDAL can read NetCDF files as raster datasets, but only when
+they follow the CF (Climate and Forecast) conventions with properly defined coordinate
+variables, dimensions, and grid mapping attributes. Unstructured NetCDF files or files that
+do not follow the CF standard structure cannot be read by GDAL.
+
+### CSV
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.csv` |
+| Media type | `text/csv` |
+| GDAL driver | CSV |
+| Categories | Bathymetry, Backscatter |
+| Stages | Raw data, QC, Interpreted data |
+
+Comma-separated or delimited text file containing point data (X, Y, Z or lon, lat, value).
+Similar to XYZ but with header row and flexible column naming. OGR reads it as a point vector
+dataset; can also be treated as raster via VRT.
+
+
+## OGR vector formats
+
+These formats are read using OGR vector drivers. The extractor can retrieve: bounding box,
+CRS/EPSG code, feature count, and geometry type.
+
+### Shapefile
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.shp` + `.shx` + `.dbf` |
+| Media type | `application/x-shapefile` |
+| OGR driver | ESRI Shapefile |
+| Categories | Bathymetry |
+| Stages | Raw data, QC, Processed data, Interpreted data |
+
+ESRI vector format storing point, line, or polygon geometries with attribute data. Companion
+files `.shx` (index) and `.dbf` (attributes) are required. Used as secondary file across all
+workflow stages.
+
+### CSV
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.csv` |
+| Media type | `text/csv` |
+| OGR driver | CSV |
+| Categories | Bathymetry, Backscatter |
+| Stages | Raw data, QC, Interpreted data |
+
+Comma-separated or delimited text file containing point data with coordinate columns
+(X/Y, lon/lat). OGR reads it as a point vector dataset when columns with coordinates are
+identified. Also listed under GDAL raster formats as it can be treated as a gridded raster
+via VRT.
+
+### File Geodatabase
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.gdb` (directory) |
+| Media type | `application/x-filegdb` |
+| OGR driver | OpenFileGDB |
+| Categories | Bathymetry, Backscatter |
+| Stages | Raw data, QC, Processed data, Interpreted data |
+
+ESRI File Geodatabase — a directory containing multiple database files that store vector and
+raster datasets. Used as secondary file for raw/QC/processed data and as primary/secondary for
+interpreted products. Read-only access via the OpenFileGDB driver (no ESRI license required).
+
+### GeoJSON
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.geojson`, `.json` |
+| Media type | `application/geo+json` |
+| OGR driver | GeoJSON |
+| Categories | Bathymetry, Backscatter |
+| Stages | Processed data, Interpreted data |
+
+Open standard format for encoding geographic data structures using JSON. Supports point, line,
+polygon, and multi-geometry types with associated properties. Always uses WGS 84 (EPSG:4326)
+as its coordinate reference system.
+
+### GeoPackage
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.gpkg` |
+| Media type | `application/geopackage+sqlite3` |
+| OGR driver | GPKG |
+| Categories | Bathymetry, Backscatter |
+| Stages | Processed data, Interpreted data |
+
+OGC open standard based on SQLite. Can store both vector and raster data in a single file.
+Supports multiple layers, spatial indexes, and arbitrary CRS. Modern alternative to Shapefile
+and File Geodatabase.
+
+### KML/KMZ
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.kml`, `.kmz` |
+| Media type | `application/vnd.google-earth.kml+xml` |
+| OGR driver | KML / LIBKML |
+| Categories | Bathymetry, Backscatter |
+| Stages | Interpreted data |
+
+Google Earth markup format for geographic visualization. KML is XML-based; KMZ is a compressed
+(ZIP) archive containing a KML file and optional resources. Supports point, line, and polygon
+geometries. Always uses WGS 84 (EPSG:4326). OGR can read both KML and KMZ via the KML or
+LIBKML drivers.
+
+
+## Specialized formats (future)
+
+These formats require dedicated extractors that are not yet implemented. They will be added in
+future iterations.
+
+### CSAR
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.csar` |
+| Media type | `application/octet-stream` |
+| Categories | Bathymetry, Backscatter |
+| Stages | Processed data |
+
+CARIS Spatial Archive file. Proprietary raster format for gridded bathymetry and elevation data.
+Used as primary file for processed data. Requires CARIS software/license for full access.
+
+### KMALL
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.kmall` |
+| Categories | Bathymetry, Backscatter |
+| Stages | Raw data |
+
+Binary datagram-based format from Kongsberg multibeam echosounder systems. Contains position
+data (latitude, longitude, timestamp), depth measurements, and quality indicators. The `#SPO`
+datagram provides position data; `#MRZ` provides depth/reflectivity.
+
+A Python reader module is available on GitHub for parsing datagrams.
+
+### SEG-Y
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.segy`, `.sgy` |
+| Categories | Seismic |
+| Stages | Raw data |
+
+Standard seismic data exchange format (SEG-Y Revision 2.0). Structure:
+
+- Text File Header (3200 bytes)
+- Binary Header (400 bytes)
+- Extended Text Header (optional)
+- Traces (individual seismic traces with 240-byte trace headers)
+
+Python libraries: **segyio** (actively maintained, by Equinor) and **segpy**.
+
+### JSF
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.jsf` |
+| Categories | Seismic |
+| Stages | Raw data |
+
+EdgeTech sonar data format. Binary format with defined header structure (JSFDefs.h).
+Used for sub-bottom profiler (SBP) raw data.
+
+### P1/11
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.p111` |
+| Categories | Geophysical position data |
+| Stages | Raw data |
+
+Geophysical position data exchange format. Can be imported using the SeisPos_Import QGIS plugin.
+
+
+## Other formats
+
+### HIPS Project
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | Directory (proprietary structure) |
+| Categories | Bathymetry |
+| Stages | Processed data |
+
+CARIS HIPS and SIPS project directory. Proprietary format containing processed multibeam data.
+No automated extraction is planned — treated as an opaque directory.
+
+### XLS
+
+| Property | Value |
+|----------|-------|
+| Extension(s) | `.xls`, `.xlsx` |
+| Media type | `application/vnd.ms-excel` |
+| Categories | Bathymetry |
+| Stages | Raw data, QC, Processed data |
+
+Spreadsheet/tabular data. Used as secondary file for metadata or ancillary information.
+No GDAL/OGR support — would require a dedicated reader if extraction is needed.

--- a/docs/supported-formats.pt.md
+++ b/docs/supported-formats.pt.md
@@ -76,7 +76,7 @@ dados processados e como principal/secundário para produtos interpretados.
 | Categorias | Batimetria, Backscatter |
 | Fases | Dados processados, Dados interpretados |
 
-Network Common Data Form — formato binário auto-descritivo amplamente utilizado em dados
+Network Common Data Form, formato binário auto-descritivo amplamente utilizado em dados
 oceanográficos, atmosféricos e climáticos. O GDAL consegue ler ficheiros NetCDF como conjuntos
 de dados raster, mas apenas quando seguem as convenções CF (Climate and Forecast) com
 variáveis de coordenadas, dimensões e atributos de mapeamento de grelha devidamente definidos.
@@ -143,7 +143,7 @@ GDAL, pois pode ser tratado como raster em grelha via VRT.
 | Categorias | Batimetria, Backscatter |
 | Fases | Dados em bruto, Controlo de qualidade, Dados processados, Dados interpretados |
 
-ESRI File Geodatabase — um diretório contendo múltiplos ficheiros de base de dados que
+ESRI File Geodatabase, um diretório contendo múltiplos ficheiros de base de dados que
 armazenam conjuntos de dados vetoriais e raster. Utilizado como ficheiro secundário para
 dados em bruto/controlo de qualidade/processados e como principal/secundário para produtos
 interpretados. Acesso apenas de leitura através do driver OpenFileGDB (sem necessidade de
@@ -277,7 +277,7 @@ SeisPos_Import do QGIS.
 | Fases | Dados processados |
 
 Diretório de projeto CARIS HIPS e SIPS. Formato proprietário contendo dados multifeixe
-processados. Não está prevista extração automatizada — tratado como um diretório opaco.
+processados. Não está prevista extração automatizada, tratado como um diretório opaco.
 
 ### XLS
 

--- a/docs/supported-formats.pt.md
+++ b/docs/supported-formats.pt.md
@@ -1,0 +1,293 @@
+# Formatos de ficheiros suportados
+
+Esta página documenta os formatos de ficheiros presentes no arquivo de dados marinhos e o
+seu estado de suporte no pipeline de extração do SeisLabData.
+
+## Formatos raster GDAL
+
+Estes formatos são lidos através de drivers raster GDAL. O extrator consegue obter: caixa
+delimitadora (bounding box), código CRS/EPSG, número de bandas, resolução de píxel e valor
+nodata.
+
+### GeoTIFF
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.tif`, `.tiff` |
+| Tipo de média | `image/tiff` |
+| Driver GDAL | GTiff |
+| Categorias | Batimetria, Backscatter |
+| Fases | Controlo de qualidade, Dados processados, Dados interpretados |
+
+Formato raster georreferenciado com CRS e metadados incorporados. Amplamente suportado em
+ferramentas SIG. Utilizado como ficheiro principal para grelhas de batimetria/backscatter
+processadas e produtos interpretados.
+
+### Grelha XYZ
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.xyz` |
+| Tipo de média | `text/plain` |
+| Driver GDAL | XYZ |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados em bruto, Controlo de qualidade, Dados interpretados |
+
+Formato de nuvem de pontos em texto simples com colunas X, Y, Z. Utilizado como ficheiro
+principal para dados de batimetria em bruto/controlo de qualidade e como ficheiro secundário
+nalgumas fases. O GDAL lê-o como um conjunto de dados raster em grelha.
+
+### ASCII Grid
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.asc` |
+| Tipo de média | `text/plain` |
+| Driver GDAL | AAIGrid |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados interpretados |
+
+Formato raster ASCII da ESRI. O cabeçalho define as dimensões da grelha, tamanho da célula,
+origem e valor nodata, seguido de valores de célula separados por espaços. Utilizado como
+ficheiro principal para produtos interpretados.
+
+### Float Grid
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.flt` + `.hdr` |
+| Tipo de média | `application/octet-stream` |
+| Driver GDAL | EHdr |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados processados, Dados interpretados |
+
+Formato raster binário que armazena valores de vírgula flutuante IEEE de 32 bits em ordem
+row-major. Requer um ficheiro de cabeçalho `.hdr` complementar contendo metadados da grelha
+(ncols, nrows, cellsize, nodata_value, byteorder). Utilizado como ficheiro secundário para
+dados processados e como principal/secundário para produtos interpretados.
+
+### NetCDF
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.nc`, `.nc4` |
+| Tipo de média | `application/x-netcdf` |
+| Driver GDAL | netCDF |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados processados, Dados interpretados |
+
+Network Common Data Form — formato binário auto-descritivo amplamente utilizado em dados
+oceanográficos, atmosféricos e climáticos. O GDAL consegue ler ficheiros NetCDF como conjuntos
+de dados raster, mas apenas quando seguem as convenções CF (Climate and Forecast) com
+variáveis de coordenadas, dimensões e atributos de mapeamento de grelha devidamente definidos.
+Ficheiros NetCDF não estruturados ou que não sigam a estrutura padrão CF não podem ser lidos
+pelo GDAL.
+
+### CSV
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.csv` |
+| Tipo de média | `text/csv` |
+| Driver GDAL | CSV |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados em bruto, Controlo de qualidade, Dados interpretados |
+
+Ficheiro de texto com valores separados por vírgulas ou delimitadores, contendo dados de
+pontos (X, Y, Z ou lon, lat, valor). Semelhante ao XYZ mas com linha de cabeçalho e nomeação
+flexível de colunas. O OGR lê-o como um conjunto de dados vetorial de pontos; pode também
+ser tratado como raster via VRT.
+
+
+## Formatos vetoriais OGR
+
+Estes formatos são lidos através de drivers vetoriais OGR. O extrator consegue obter: caixa
+delimitadora (bounding box), código CRS/EPSG, contagem de elementos e tipo de geometria.
+
+### Shapefile
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.shp` + `.shx` + `.dbf` |
+| Tipo de média | `application/x-shapefile` |
+| Driver OGR | ESRI Shapefile |
+| Categorias | Batimetria |
+| Fases | Dados em bruto, Controlo de qualidade, Dados processados, Dados interpretados |
+
+Formato vetorial ESRI que armazena geometrias de pontos, linhas ou polígonos com dados de
+atributos. Os ficheiros complementares `.shx` (índice) e `.dbf` (atributos) são obrigatórios.
+Utilizado como ficheiro secundário em todas as fases do fluxo de trabalho.
+
+### CSV
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.csv` |
+| Tipo de média | `text/csv` |
+| Driver OGR | CSV |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados em bruto, Controlo de qualidade, Dados interpretados |
+
+Ficheiro de texto com valores separados por vírgulas ou delimitadores, contendo dados de pontos
+com colunas de coordenadas (X/Y, lon/lat). O OGR lê-o como um conjunto de dados vetorial de
+pontos quando as colunas com coordenadas são identificadas. Também listado nos formatos raster
+GDAL, pois pode ser tratado como raster em grelha via VRT.
+
+### File Geodatabase
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.gdb` (diretório) |
+| Tipo de média | `application/x-filegdb` |
+| Driver OGR | OpenFileGDB |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados em bruto, Controlo de qualidade, Dados processados, Dados interpretados |
+
+ESRI File Geodatabase — um diretório contendo múltiplos ficheiros de base de dados que
+armazenam conjuntos de dados vetoriais e raster. Utilizado como ficheiro secundário para
+dados em bruto/controlo de qualidade/processados e como principal/secundário para produtos
+interpretados. Acesso apenas de leitura através do driver OpenFileGDB (sem necessidade de
+licença ESRI).
+
+### GeoJSON
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.geojson`, `.json` |
+| Tipo de média | `application/geo+json` |
+| Driver OGR | GeoJSON |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados processados, Dados interpretados |
+
+Formato aberto para codificação de estruturas de dados geográficos em JSON. Suporta geometrias
+de pontos, linhas, polígonos e multi-geometrias com propriedades associadas. Utiliza sempre
+WGS 84 (EPSG:4326) como sistema de referência de coordenadas.
+
+### GeoPackage
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.gpkg` |
+| Tipo de média | `application/geopackage+sqlite3` |
+| Driver OGR | GPKG |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados processados, Dados interpretados |
+
+Norma aberta OGC baseada em SQLite. Permite armazenar dados vetoriais e raster num único
+ficheiro. Suporta múltiplas camadas, índices espaciais e CRS arbitrário. Alternativa moderna
+ao Shapefile e ao File Geodatabase.
+
+### KML/KMZ
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.kml`, `.kmz` |
+| Tipo de média | `application/vnd.google-earth.kml+xml` |
+| Driver OGR | KML / LIBKML |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados interpretados |
+
+Formato de marcação do Google Earth para visualização geográfica. O KML é baseado em XML;
+o KMZ é um arquivo comprimido (ZIP) contendo um ficheiro KML e recursos opcionais. Suporta
+geometrias de pontos, linhas e polígonos. Utiliza sempre WGS 84 (EPSG:4326). O OGR consegue
+ler tanto KML como KMZ através dos drivers KML ou LIBKML.
+
+
+## Formatos especializados (futuro)
+
+Estes formatos requerem extratores dedicados que ainda não estão implementados. Serão
+adicionados em iterações futuras.
+
+### CSAR
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.csar` |
+| Tipo de média | `application/octet-stream` |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados processados |
+
+Ficheiro CARIS Spatial Archive. Formato raster proprietário para dados de batimetria e
+elevação em grelha. Utilizado como ficheiro principal para dados processados. Requer
+software/licença CARIS para acesso completo.
+
+### KMALL
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.kmall` |
+| Categorias | Batimetria, Backscatter |
+| Fases | Dados em bruto |
+
+Formato binário baseado em datagramas dos sistemas de ecossonda multifeixe Kongsberg. Contém
+dados de posição (latitude, longitude, marca temporal), medições de profundidade e indicadores
+de qualidade. O datagrama `#SPO` fornece dados de posição; o `#MRZ` fornece
+profundidade/refletividade.
+
+Um módulo Python para leitura de datagramas está disponível no GitHub.
+
+### SEG-Y
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.segy`, `.sgy` |
+| Categorias | Sísmica |
+| Fases | Dados em bruto |
+
+Formato padrão de troca de dados sísmicos (SEG-Y Revisão 2.0). Estrutura:
+
+- Cabeçalho de texto (3200 bytes)
+- Cabeçalho binário (400 bytes)
+- Cabeçalho de texto estendido (opcional)
+- Traços (traços sísmicos individuais com cabeçalhos de 240 bytes)
+
+Bibliotecas Python: **segyio** (mantida ativamente, pela Equinor) e **segpy**.
+
+### JSF
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.jsf` |
+| Categorias | Sísmica |
+| Fases | Dados em bruto |
+
+Formato de dados de sonar EdgeTech. Formato binário com estrutura de cabeçalho definida
+(JSFDefs.h). Utilizado para dados em bruto de perfilador de sub-fundo (SBP).
+
+### P1/11
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.p111` |
+| Categorias | Dados de posição geofísica |
+| Fases | Dados em bruto |
+
+Formato de troca de dados de posição geofísica. Pode ser importado utilizando o plugin
+SeisPos_Import do QGIS.
+
+
+## Outros formatos
+
+### Projeto HIPS
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | Diretório (estrutura proprietária) |
+| Categorias | Batimetria |
+| Fases | Dados processados |
+
+Diretório de projeto CARIS HIPS e SIPS. Formato proprietário contendo dados multifeixe
+processados. Não está prevista extração automatizada — tratado como um diretório opaco.
+
+### XLS
+
+| Propriedade | Valor |
+|-------------|-------|
+| Extensão(ões) | `.xls`, `.xlsx` |
+| Tipo de média | `application/vnd.ms-excel` |
+| Categorias | Batimetria |
+| Fases | Dados em bruto, Controlo de qualidade, Dados processados |
+
+Dados tabulares em folha de cálculo. Utilizado como ficheiro secundário para metadados ou
+informação auxiliar. Sem suporte GDAL/OGR — necessitaria de um leitor dedicado caso a
+extração seja necessária.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ nav:
   - Administration Guide: admin-guide.md
   - Test environment: test-environment.md
   - Development: development.md
+  - Dataset reference: dataset-reference.md
+  - Supported formats: supported-formats.md
   - Writing docs: writing-docs.md
 
 theme:
@@ -44,6 +46,8 @@ plugins:
             - Guia de administração do sistema: admin-guide.md
             - Guia do ambiente de testes: test-environment.md
             - Guia de desenvolvimento: development.md
+            - Referência de dados: dataset-reference.md
+            - Formatos suportados: supported-formats.md
             - Guia de escrita de documentação: writing-docs.md
 
 markdown_extensions:


### PR DESCRIPTION
I updated the Dataset reference based on [./src/seis_lab_data/cliapp/bootstrapdata.py](https://github.com/NaturalGIS/seis-lab-data/blob/main/src/seis_lab_data/cliapp/bootstrapdata.py) not totally sure if this is the most update reference. 

On the supported file formats I keep the usage based on the wiki but I'm not sure if its relevant. 

Portuguese version was auto-translated and poorly corrected by me, my Portuguese writing skills might actually be worse than my English these days.

@ricardogsilva your inputs/changes/adaptations are welcome. 

@ricardogsilva can you also check `docs/dataset-reference.md` I tried to create a matrix the best I can but I might have missed something.

--- 
- fixes #114 