### PR TITLE
added e2e tests for asset discovery conf, category and workflow stage

### DIFF
--- a/src/seis_lab_data/webapp/filters.py
+++ b/src/seis_lab_data/webapp/filters.py
@@ -136,8 +136,8 @@ class _StringFilter(SimpleListFilter):
 
 @dataclasses.dataclass
 class NameFilter(_StringFilter):
-    internal_name = "name_filter"
-    public_name = "name"
+    internal_name: str = "name_filter"
+    public_name: str = "name"
 
 
 @dataclasses.dataclass

--- a/src/seis_lab_data/webapp/streamhandlers/common.py
+++ b/src/seis_lab_data/webapp/streamhandlers/common.py
@@ -43,7 +43,7 @@ async def flash_ui_message_after_redirect(
     }
     logger.debug(f"{payload=}")
     yield ServerSentEventGenerator.execute_script(
-        f"localStorage.setItem('sld:flash', '{json.dumps(payload)}');"
+        f"localStorage.setItem('sld:flash', {json.dumps(json.dumps(payload))});"
     )
 
 

--- a/src/seis_lab_data/webapp/templates/macros-buttons.html
+++ b/src/seis_lab_data/webapp/templates/macros-buttons.html
@@ -40,11 +40,12 @@
     size_css_class=None
 ) %}
 
+    {% set modal_id = "delete-item-modal-" ~ signal_name %}
     <button
             class="btn btn-outline-danger{% if size_css_class %} {{ size_css_class }}{% endif %}"
             aria-label="show-delete-confirmation-modal"
             data-bs-toggle="modal"
-            data-bs-target="#delete-item-modal"
+            data-bs-target="#{{ modal_id }}"
             data-attr:disabled="${{ signal_name }}"
     >
         <span class="material-icons-outlined me-1">{{ icons.delete_item }}</span><span data-text="${{ signal_name }} ? '{{ running_message }}' : '{{ idle_message }}...'"></span>
@@ -54,16 +55,16 @@
         <span class="visually-hidden">{{ _("Loading...") }}</span>
     </div>
     <div
-            id="delete-item-modal"
+            id="{{ modal_id }}"
             class="modal fade"
             tabindex="-1"
-            aria-labelledby="delete-item-modal-label"
+            aria-labelledby="{{ modal_id }}-label"
             aria-hidden="true"
     >
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h1 class="modal-title fs-5" id="delete-item-modal-label">{{ modal_dialog_title | capitalize }}</h1>
+                    <h1 class="modal-title fs-5" id="{{ modal_id }}-label">{{ modal_dialog_title | capitalize }}</h1>
                     <button
                             type="button"
                             class="btn-close"

--- a/tests/e2e/test_e2e_asset_discovery_configurations.py
+++ b/tests/e2e/test_e2e_asset_discovery_configurations.py
@@ -1,0 +1,171 @@
+import re
+import uuid
+from urllib.parse import urlencode
+
+import pytest
+from playwright.sync_api import (
+    Locator,
+    Page,
+    expect,
+)
+
+
+def _fill_asset_discovery_configuration_form(
+    page: Page, name: str, relative_path_regexp: str
+):
+    # unlike dataset categories / workflow stages, the name here is a plain (not
+    # localizable) field, and there are two additional required associations
+    page.get_by_role("textbox", name="field-name").fill(name)
+    page.get_by_role("textbox", name="field-relative_path_regexp").fill(
+        relative_path_regexp
+    )
+    # pick whatever the first available option is for each association — the test
+    # only cares that some valid dataset category / workflow stage gets linked,
+    # not which one, so it doesn't need to hardcode sample data names
+    page.get_by_role("combobox", name="field-dataset_category_id").select_option(
+        index=0
+    )
+    page.get_by_role("combobox", name="field-workflow_stage_id").select_option(index=0)
+
+
+def _find_asset_discovery_configuration_card(page: Page, name: str) -> Locator:
+    """Locate the listing-page card for a given asset discovery configuration.
+
+    Asset discovery configurations have no dedicated detail page, same as dataset
+    categories / workflow stages. However, unlike those two, the in-page search
+    box here doesn't actually filter anything: it sends a `search` signal, but the
+    server-side filter for this resource only ever looks for a `name` query
+    parameter (see `AssetDiscoveryConfigurationListFilters`/`NameFilter` in
+    `webapp/filters.py`), so the search input is a no-op for this resource. The
+    reliable way to isolate a single item regardless of pagination/sort order is
+    to navigate directly with that `name` query parameter instead, which the
+    initial listing GET endpoint does honor (as an `ilike` substring match).
+    """
+    page.goto(f"/asset-discovery-configurations/?{urlencode({'name': name})}")
+    card = page.locator(".card", has_text=name)
+    expect(card).to_be_visible(timeout=10_000)
+    return card
+
+
+@pytest.mark.e2e
+def test_asset_discovery_configuration_lifecycle(authenticated_page: Page):
+    # start from the landing page
+    authenticated_page.goto("/")
+
+    resource_name_id = uuid.uuid4().hex[:8]
+
+    # navigate to the asset discovery configurations page and click the create new button
+    authenticated_page.get_by_role("button", name="settings").click()
+    authenticated_page.get_by_role(
+        "link", name="list-asset-discovery-configurations"
+    ).click()
+    authenticated_page.get_by_role(
+        "link", name="new-asset-discovery-configuration"
+    ).click()
+
+    # hit the cancel button and verify we are brought back to the listing page
+    authenticated_page.get_by_role("link", name="cancel-creation").click()
+
+    authenticated_page.get_by_role(
+        "link", name="new-asset-discovery-configuration"
+    ).click()
+
+    # fill out the form and submit it — use a unique suffix to avoid collisions across runs
+    config_name = f"e2e test asset discovery configuration {resource_name_id}"
+    _fill_asset_discovery_configuration_form(
+        authenticated_page, config_name, r".*\.tif$"
+    )
+
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+
+    # expect to be redirected to the listing page upon successful creation
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/asset-discovery-configurations/$"), timeout=10_000
+    )
+
+    # find the newly-created configuration and open its edit form
+    card = _find_asset_discovery_configuration_card(authenticated_page, config_name)
+    card.get_by_role("link").click()
+
+    updated_config_name = f"{config_name} (updated)"
+    _fill_asset_discovery_configuration_form(
+        authenticated_page, updated_config_name, r".*\.jp2$"
+    )
+    authenticated_page.get_by_role("button", name="submit-update-form").click()
+
+    # expect to be redirected to the listing page upon successful modification
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/asset-discovery-configurations/$"), timeout=10_000
+    )
+    card = _find_asset_discovery_configuration_card(
+        authenticated_page, updated_config_name
+    )
+
+    # now try to modify the configuration again, but this time hit the cancel button
+    card.get_by_role("link").click()
+    authenticated_page.get_by_role("link", name="cancel-update").click()
+
+    # expect to be redirected to the listing page upon cancelling the modification
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/asset-discovery-configurations/$"), timeout=10_000
+    )
+
+    # clean up by deleting the newly-created configuration
+    card = _find_asset_discovery_configuration_card(
+        authenticated_page, updated_config_name
+    )
+    card.get_by_role("button", name="show-delete-confirmation-modal").click()
+    authenticated_page.get_by_role("button", name="delete-item").click()
+    expect(card).not_to_be_visible()
+
+
+@pytest.mark.e2e
+def test_asset_discovery_configuration_creation_rejects_duplicate_name(
+    authenticated_page: Page,
+):
+    authenticated_page.goto("/")
+    authenticated_page.get_by_role("button", name="settings").click()
+    authenticated_page.get_by_role(
+        "link", name="list-asset-discovery-configurations"
+    ).click()
+
+    # create an initial configuration
+    resource_name_id = uuid.uuid4().hex[:8]
+    config_name = f"e2e duplicate test {resource_name_id}"
+    authenticated_page.get_by_role(
+        "link", name="new-asset-discovery-configuration"
+    ).click()
+    _fill_asset_discovery_configuration_form(
+        authenticated_page, config_name, r".*\.tif$"
+    )
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/asset-discovery-configurations/$"), timeout=10_000
+    )
+
+    # navigate to the create form and submit with the same (globally unique) name
+    authenticated_page.get_by_role(
+        "link", name="new-asset-discovery-configuration"
+    ).click()
+    _fill_asset_discovery_configuration_form(
+        authenticated_page, config_name, r".*\.jp2$"
+    )
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+
+    # unlike dataset categories / workflow stages, name uniqueness here is only
+    # enforced at the database level and discovered asynchronously by the
+    # background worker — the app redirects to the listing page regardless of
+    # outcome, and reports the failure via a flash notification rather than an
+    # inline field error
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/asset-discovery-configurations/$"), timeout=10_000
+    )
+    expect(authenticated_page.locator(".toast.text-bg-danger")).to_be_visible(
+        timeout=10_000
+    )
+
+    # clean up the single (successfully-created) configuration
+    card = _find_asset_discovery_configuration_card(authenticated_page, config_name)
+    card.get_by_role("button", name="show-delete-confirmation-modal").click()
+    authenticated_page.get_by_role("button", name="delete-item").click()
+    expect(card).not_to_be_visible()

--- a/tests/e2e/test_e2e_dataset_categories.py
+++ b/tests/e2e/test_e2e_dataset_categories.py
@@ -1,0 +1,146 @@
+import re
+import uuid
+
+import pytest
+from playwright.sync_api import (
+    Locator,
+    Page,
+    expect,
+)
+
+
+def _fill_dataset_category_form(page: Page, english_name: str, portuguese_name: str):
+    # the name field is rendered by jsoneditor (as a table of key/value rows) rather
+    # than as plain textboxes, so it must be filled by locating each row by its key
+    name_editor = page.locator("#name-editor")
+    name_editor.locator(".jsoneditor-field", has_text=re.compile(r"^en$")).locator(
+        "xpath=ancestor::tr[1]"
+    ).locator(".jsoneditor-value").fill(english_name)
+    name_editor.locator(".jsoneditor-field", has_text=re.compile(r"^pt$")).locator(
+        "xpath=ancestor::tr[1]"
+    ).locator(".jsoneditor-value").fill(portuguese_name)
+
+
+def _find_dataset_category_card(page: Page, portuguese_name: str) -> Locator:
+    """Locate the listing-page card for a given dataset category.
+
+    Dataset categories have no dedicated detail page — every action (view, edit,
+    delete) happens from the listing page, which is paginated and sorted by name
+    rather than by creation time. Filtering through the search box narrows the
+    list down to the single matching item, which makes the card easy to find
+    regardless of pagination/ordering, and also means only one delete-confirmation
+    modal is present in the DOM when the delete button is clicked.
+
+    The e2e test session runs under the app's default (Portuguese) locale, and
+    the search box filters by whichever name field matches the active locale —
+    so it must be searched by the category's Portuguese name, which is why the
+    test data always gives each category a unique Portuguese name too.
+    """
+    page.get_by_role("searchbox", name="search dataset categories").fill(
+        portuguese_name
+    )
+    card = page.locator(".card", has_text=portuguese_name)
+    expect(card).to_be_visible(timeout=10_000)
+    return card
+
+
+@pytest.mark.e2e
+def test_dataset_category_lifecycle(authenticated_page: Page):
+    # start from the landing page
+    authenticated_page.goto("/")
+
+    resource_name_id = uuid.uuid4().hex[:8]
+
+    # navigate to the dataset categories page and click the create new button
+    authenticated_page.get_by_role("button", name="settings").click()
+    authenticated_page.get_by_role("link", name="list-dataset-categories").click()
+    authenticated_page.get_by_role("link", name="new-dataset-category").click()
+
+    # hit the cancel button and verify we are brought back to the listing page
+    authenticated_page.get_by_role("link", name="cancel-creation").click()
+
+    authenticated_page.get_by_role("link", name="new-dataset-category").click()
+
+    # fill out the form and submit it — use a unique suffix to avoid collisions across runs
+    category_name = f"e2e test dataset category {resource_name_id}"
+    category_name_pt = f"categoria de teste e2e {resource_name_id}"
+    _fill_dataset_category_form(authenticated_page, category_name, category_name_pt)
+
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+
+    # expect to be redirected to the listing page upon successful creation
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/dataset-categories/$"), timeout=10_000
+    )
+
+    # find the newly-created category and open its edit form
+    card = _find_dataset_category_card(authenticated_page, category_name_pt)
+    card.get_by_role("link").click()
+
+    updated_category_name = f"{category_name} (updated)"
+    _fill_dataset_category_form(
+        authenticated_page, updated_category_name, category_name_pt
+    )
+    authenticated_page.get_by_role("button", name="submit-update-form").click()
+
+    # expect to be redirected to the listing page upon successful modification
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/dataset-categories/$"), timeout=10_000
+    )
+    card = _find_dataset_category_card(authenticated_page, category_name_pt)
+
+    # now try to modify the category again, but this time hit the cancel button
+    card.get_by_role("link").click()
+    authenticated_page.get_by_role("link", name="cancel-update").click()
+
+    # expect to be redirected to the listing page upon cancelling the modification
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/dataset-categories/$"), timeout=10_000
+    )
+
+    # clean up by deleting the newly-created category
+    card = _find_dataset_category_card(authenticated_page, category_name_pt)
+    card.get_by_role("button", name="show-delete-confirmation-modal").click()
+    authenticated_page.get_by_role("button", name="delete-item").click()
+    expect(card).not_to_be_visible()
+
+
+@pytest.mark.e2e
+def test_dataset_category_creation_rejects_duplicate_english_name(
+    authenticated_page: Page,
+):
+    authenticated_page.goto("/")
+    authenticated_page.get_by_role("button", name="settings").click()
+    authenticated_page.get_by_role("link", name="list-dataset-categories").click()
+
+    # create an initial category
+    resource_name_id = uuid.uuid4().hex[:8]
+    category_name = f"e2e duplicate test {resource_name_id}"
+    category_name_pt = f"categoria de teste duplicado {resource_name_id}"
+    authenticated_page.get_by_role("link", name="new-dataset-category").click()
+    _fill_dataset_category_form(authenticated_page, category_name, category_name_pt)
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/dataset-categories/$"), timeout=10_000
+    )
+
+    # navigate to the create form and submit with the same english name
+    # (the portuguese name only needs to be unique from other categories, not
+    # from the first one, since it's the english name uniqueness being tested)
+    authenticated_page.get_by_role("link", name="new-dataset-category").click()
+    _fill_dataset_category_form(
+        authenticated_page, category_name, f"{category_name_pt} 2"
+    )
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+
+    # the form should re-render in place with an inline error on the name field
+    expect(
+        authenticated_page.locator("#backend-validation-name-feedback")
+    ).to_be_visible()
+
+    # clean up by navigating back to the listing page and deleting the category
+    authenticated_page.get_by_role("link", name="cancel-creation").click()
+    card = _find_dataset_category_card(authenticated_page, category_name_pt)
+    card.get_by_role("button", name="show-delete-confirmation-modal").click()
+    authenticated_page.get_by_role("button", name="delete-item").click()
+    expect(card).not_to_be_visible()

--- a/tests/e2e/test_e2e_workflow_stages.py
+++ b/tests/e2e/test_e2e_workflow_stages.py
@@ -1,0 +1,140 @@
+import re
+import uuid
+
+import pytest
+from playwright.sync_api import (
+    Locator,
+    Page,
+    expect,
+)
+
+
+def _fill_workflow_stage_form(page: Page, english_name: str, portuguese_name: str):
+    # the name field is rendered by jsoneditor (as a table of key/value rows) rather
+    # than as plain textboxes, so it must be filled by locating each row by its key
+    name_editor = page.locator("#name-editor")
+    name_editor.locator(".jsoneditor-field", has_text=re.compile(r"^en$")).locator(
+        "xpath=ancestor::tr[1]"
+    ).locator(".jsoneditor-value").fill(english_name)
+    name_editor.locator(".jsoneditor-field", has_text=re.compile(r"^pt$")).locator(
+        "xpath=ancestor::tr[1]"
+    ).locator(".jsoneditor-value").fill(portuguese_name)
+
+
+def _find_workflow_stage_card(page: Page, portuguese_name: str) -> Locator:
+    """Locate the listing-page card for a given workflow stage.
+
+    Workflow stages have no dedicated detail page — every action (view, edit,
+    delete) happens from the listing page, which is paginated and sorted by name
+    rather than by creation time. Filtering through the search box narrows the
+    list down to the single matching item, which makes the card easy to find
+    regardless of pagination/ordering, and also means only one delete-confirmation
+    modal is present in the DOM when the delete button is clicked.
+
+    The e2e test session runs under the app's default (Portuguese) locale, and
+    the search box filters by whichever name field matches the active locale —
+    so it must be searched by the stage's Portuguese name, which is why the
+    test data always gives each stage a unique Portuguese name too.
+    """
+    page.get_by_role("searchbox", name="search workflow stages").fill(portuguese_name)
+    card = page.locator(".card", has_text=portuguese_name)
+    expect(card).to_be_visible(timeout=10_000)
+    return card
+
+
+@pytest.mark.e2e
+def test_workflow_stage_lifecycle(authenticated_page: Page):
+    # start from the landing page
+    authenticated_page.goto("/")
+
+    resource_name_id = uuid.uuid4().hex[:8]
+
+    # navigate to the workflow stages page and click the create new button
+    authenticated_page.get_by_role("button", name="settings").click()
+    authenticated_page.get_by_role("link", name="list-workflow-stages").click()
+    authenticated_page.get_by_role("link", name="new-workflow-stage").click()
+
+    # hit the cancel button and verify we are brought back to the listing page
+    authenticated_page.get_by_role("link", name="cancel-creation").click()
+
+    authenticated_page.get_by_role("link", name="new-workflow-stage").click()
+
+    # fill out the form and submit it — use a unique suffix to avoid collisions across runs
+    stage_name = f"e2e test workflow stage {resource_name_id}"
+    stage_name_pt = f"fase de teste e2e {resource_name_id}"
+    _fill_workflow_stage_form(authenticated_page, stage_name, stage_name_pt)
+
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+
+    # expect to be redirected to the listing page upon successful creation
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/workflow-stages/$"), timeout=10_000
+    )
+
+    # find the newly-created stage and open its edit form
+    card = _find_workflow_stage_card(authenticated_page, stage_name_pt)
+    card.get_by_role("link").click()
+
+    updated_stage_name = f"{stage_name} (updated)"
+    _fill_workflow_stage_form(authenticated_page, updated_stage_name, stage_name_pt)
+    authenticated_page.get_by_role("button", name="submit-update-form").click()
+
+    # expect to be redirected to the listing page upon successful modification
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/workflow-stages/$"), timeout=10_000
+    )
+    card = _find_workflow_stage_card(authenticated_page, stage_name_pt)
+
+    # now try to modify the stage again, but this time hit the cancel button
+    card.get_by_role("link").click()
+    authenticated_page.get_by_role("link", name="cancel-update").click()
+
+    # expect to be redirected to the listing page upon cancelling the modification
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/workflow-stages/$"), timeout=10_000
+    )
+
+    # clean up by deleting the newly-created stage
+    card = _find_workflow_stage_card(authenticated_page, stage_name_pt)
+    card.get_by_role("button", name="show-delete-confirmation-modal").click()
+    authenticated_page.get_by_role("button", name="delete-item").click()
+    expect(card).not_to_be_visible()
+
+
+@pytest.mark.e2e
+def test_workflow_stage_creation_rejects_duplicate_english_name(
+    authenticated_page: Page,
+):
+    authenticated_page.goto("/")
+    authenticated_page.get_by_role("button", name="settings").click()
+    authenticated_page.get_by_role("link", name="list-workflow-stages").click()
+
+    # create an initial stage
+    resource_name_id = uuid.uuid4().hex[:8]
+    stage_name = f"e2e duplicate test {resource_name_id}"
+    stage_name_pt = f"fase de teste duplicado {resource_name_id}"
+    authenticated_page.get_by_role("link", name="new-workflow-stage").click()
+    _fill_workflow_stage_form(authenticated_page, stage_name, stage_name_pt)
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+    expect(authenticated_page).to_have_url(
+        re.compile(r"/workflow-stages/$"), timeout=10_000
+    )
+
+    # navigate to the create form and submit with the same english name
+    # (the portuguese name only needs to be unique from other stages, not
+    # from the first one, since it's the english name uniqueness being tested)
+    authenticated_page.get_by_role("link", name="new-workflow-stage").click()
+    _fill_workflow_stage_form(authenticated_page, stage_name, f"{stage_name_pt} 2")
+    authenticated_page.get_by_role("button", name="submit-create-form").click()
+
+    # the form should re-render in place with an inline error on the name field
+    expect(
+        authenticated_page.locator("#backend-validation-name-feedback")
+    ).to_be_visible()
+
+    # clean up by navigating back to the listing page and deleting the stage
+    authenticated_page.get_by_role("link", name="cancel-creation").click()
+    card = _find_workflow_stage_card(authenticated_page, stage_name_pt)
+    card.get_by_role("button", name="show-delete-confirmation-modal").click()
+    authenticated_page.get_by_role("button", name="delete-item").click()
+    expect(card).not_to_be_visible()


### PR DESCRIPTION
This PR adds additional e2e tests for verifying

- asset discovery configuration
- dataset category
- workflow stage

It also fixes a couple of bugs uncovered along the way

---

- fixes #140 
- fixes #141 
- fixes #142