### PR TITLE
Added search filters to survey-mission detail page

### DIFF
--- a/src/seis_lab_data/db/commands/surveyrelatedrecords.py
+++ b/src/seis_lab_data/db/commands/surveyrelatedrecords.py
@@ -227,6 +227,9 @@ async def bulk_update_filtered_records(
     spatial_intersect: shapely.Polygon | None = None,
     temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
     asset_path_fragment_filter: str | None = None,
+    asset_media_type_filter: str | None = None,
+    dataset_category_id: identifiers.DatasetCategoryId | None = None,
+    workflow_stage_id: identifiers.WorkflowStageId | None = None,
 ) -> int:
     filter_kwargs = dict(
         survey_mission_id=survey_mission_id,
@@ -235,6 +238,9 @@ async def bulk_update_filtered_records(
         spatial_intersect=spatial_intersect,
         temporal_extent=temporal_extent,
         asset_path_fragment_filter=asset_path_fragment_filter,
+        asset_media_type_filter=asset_media_type_filter,
+        dataset_category_id=dataset_category_id,
+        workflow_stage_id=workflow_stage_id,
         excluded_record_ids=excluded_record_ids,
     )
     if restrict_to_owned:

--- a/src/seis_lab_data/db/queries/surveyrelatedrecords.py
+++ b/src/seis_lab_data/db/queries/surveyrelatedrecords.py
@@ -175,6 +175,7 @@ def _build_survey_related_record_id_statement(
     spatial_intersect: shapely.Polygon | None = None,
     temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
     asset_path_fragment_filter: str | None = None,
+    asset_media_type_filter: str | None = None,
     record_ids: list[identifiers.SurveyRelatedRecordId] | None = None,
     dataset_category_id: identifiers.DatasetCategoryId | None = None,
     workflow_stage_id: identifiers.WorkflowStageId | None = None,
@@ -192,6 +193,7 @@ def _build_survey_related_record_id_statement(
         spatial_intersect=spatial_intersect,
         temporal_extent=temporal_extent,
         asset_path_fragment_filter=asset_path_fragment_filter,
+        asset_media_type_filter=asset_media_type_filter,
         record_ids=record_ids,
         dataset_category_id=dataset_category_id,
         workflow_stage_id=workflow_stage_id,
@@ -345,8 +347,11 @@ def build_survey_related_record_id_statement(
     spatial_intersect: shapely.Polygon | None = None,
     temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
     asset_path_fragment_filter: str | None = None,
+    asset_media_type_filter: str | None = None,
     record_ids: list[identifiers.SurveyRelatedRecordId] | None = None,
     excluded_record_ids: list[identifiers.SurveyRelatedRecordId] | None = None,
+    dataset_category_id: identifiers.DatasetCategoryId | None = None,
+    workflow_stage_id: identifiers.WorkflowStageId | None = None,
 ):
     """Build a statement selecting the ids of matching records, unrestricted.
 
@@ -359,7 +364,10 @@ def build_survey_related_record_id_statement(
         spatial_intersect,
         temporal_extent,
         asset_path_fragment_filter,
+        asset_media_type_filter,
         record_ids,
+        dataset_category_id,
+        workflow_stage_id,
     )
     if excluded_record_ids:
         statement = statement.where(
@@ -376,8 +384,11 @@ def build_owned_survey_related_record_id_statement(
     spatial_intersect: shapely.Polygon | None = None,
     temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
     asset_path_fragment_filter: str | None = None,
+    asset_media_type_filter: str | None = None,
     record_ids: list[identifiers.SurveyRelatedRecordId] | None = None,
     excluded_record_ids: list[identifiers.SurveyRelatedRecordId] | None = None,
+    dataset_category_id: identifiers.DatasetCategoryId | None = None,
+    workflow_stage_id: identifiers.WorkflowStageId | None = None,
 ):
     """Build a statement selecting the ids of matching records a user owns.
 
@@ -392,7 +403,10 @@ def build_owned_survey_related_record_id_statement(
             spatial_intersect,
             temporal_extent,
             asset_path_fragment_filter,
+            asset_media_type_filter,
             record_ids,
+            dataset_category_id,
+            workflow_stage_id,
         ),
         user_id,
     )

--- a/src/seis_lab_data/operations/surveyrelatedrecords.py
+++ b/src/seis_lab_data/operations/surveyrelatedrecords.py
@@ -508,6 +508,9 @@ async def bulk_update_survey_related_records(
     spatial_intersect: shapely.Polygon | None = None,
     temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
     asset_path_fragment_filter: str | None = None,
+    asset_media_type_filter: str | None = None,
+    dataset_category_id: identifiers.DatasetCategoryId | None = None,
+    workflow_stage_id: identifiers.WorkflowStageId | None = None,
 ) -> int | None:
     """Bulk-update either a manually selected set of records or all matching a filter.
 
@@ -549,6 +552,9 @@ async def bulk_update_survey_related_records(
                 spatial_intersect=spatial_intersect,
                 temporal_extent=temporal_extent,
                 asset_path_fragment_filter=asset_path_fragment_filter,
+                asset_media_type_filter=asset_media_type_filter,
+                dataset_category_id=dataset_category_id,
+                workflow_stage_id=workflow_stage_id,
             )
     except errors.SeisLabDataError as err:
         await event_dispatcher(

--- a/src/seis_lab_data/schemas/surveyrelatedrecords.py
+++ b/src/seis_lab_data/schemas/surveyrelatedrecords.py
@@ -160,7 +160,8 @@ class SurveyRelatedRecordBulkUpdateSelection(pydantic.BaseModel):
     temporal_extent: TemporalExtentFilterValue | None = None
     asset_path_fragment_filter: str | None = None
     asset_media_type_filter: str | None = None
-    asset_path_fragment_filter: str | None = None
+    dataset_category_id: DatasetCategoryId | None = None
+    workflow_stage_id: WorkflowStageId | None = None
 
 
 class SurveyRelatedRecordUpdate(pydantic.BaseModel):

--- a/src/seis_lab_data/schemas/webui.py
+++ b/src/seis_lab_data/schemas/webui.py
@@ -106,3 +106,8 @@ class SurveyMissionDetails(
     ItemDetails[SurveyMissionReadDetail, SurveyRelatedRecordReadDetail]
 ):
     """Details for a survey mission, including its records, permissions and pagination."""
+
+    dataset_categories: list[tuple[str, str]]
+    workflow_stages: list[tuple[str, str]]
+    filter_media_types_datalist: list[str]
+    current_temporal_extent: dict[str, str | None]

--- a/src/seis_lab_data/tasks/surveyrelatedrecords.py
+++ b/src/seis_lab_data/tasks/surveyrelatedrecords.py
@@ -151,4 +151,7 @@ async def bulk_update_survey_related_records(
             spatial_intersect=selection.spatial_intersect,
             temporal_extent=selection.temporal_extent,
             asset_path_fragment_filter=selection.asset_path_fragment_filter,
+            asset_media_type_filter=selection.asset_media_type_filter,
+            dataset_category_id=selection.dataset_category_id,
+            workflow_stage_id=selection.workflow_stage_id,
         )

--- a/src/seis_lab_data/webapp/routes/surveymissions.py
+++ b/src/seis_lab_data/webapp/routes/surveymissions.py
@@ -22,9 +22,15 @@ from ... import (
     constants,
     errors,
     geojson,
+    localization,
     subscribers,
 )
-from ...db.queries import surveyrelatedrecords as record_queries
+from ...db.queries import (
+    datasetcategories as category_queries,
+    recordassets as asset_queries,
+    surveyrelatedrecords as record_queries,
+    workflowstages as stage_queries,
+)
 from ...operations import (
     projects as project_ops,
     surveymissions as survey_mission_ops,
@@ -109,7 +115,37 @@ async def _get_survey_mission_details(
             page_size=settings.pagination_page_size,
             **filter_kwargs,
         )
+        dataset_category_filter_options = [
+            (
+                dataset_category.id,
+                localization.translate_localizable_dict(
+                    dataset_category.name, current_language
+                ),
+            )
+            for dataset_category in await category_queries.collect_all_dataset_categories(
+                session
+            )
+        ]
+        workflow_stage_filter_options = [
+            (
+                workflow_stage.id,
+                localization.translate_localizable_dict(
+                    workflow_stage.name, current_language
+                ),
+            )
+            for workflow_stage in await stage_queries.collect_all_workflow_stages(
+                session
+            )
+        ]
+        media_type_filter_options = await asset_queries.list_media_types(session)
     return webui_schemas.SurveyMissionDetails(
+        dataset_categories=dataset_category_filter_options,
+        workflow_stages=workflow_stage_filter_options,
+        filter_media_types_datalist=media_type_filter_options,
+        current_temporal_extent={
+            "begin": settings.default_temporal_extent_begin,
+            "end": settings.default_temporal_extent_end,
+        },
         item=webui_schemas.SurveyMissionReadDetail.from_db_instance(survey_mission),
         children=[
             webui_schemas.SurveyRelatedRecordReadListItem.from_db_instance(srr)
@@ -196,6 +232,10 @@ async def get_details_component(request: Request):
         survey_related_records=details.children,
         search_initial_value=details.children_filter,
         permissions=details.permissions,
+        dataset_categories=details.dataset_categories,
+        workflow_stages=details.workflow_stages,
+        filter_media_types_datalist=details.filter_media_types_datalist,
+        current_temporal_extent=details.current_temporal_extent,
     )
 
     async def event_streamer():
@@ -613,6 +653,10 @@ class SurveyMissionDetailEndpoint(HTTPEndpoint):
                 "search_initial_value": details.children_filter,
                 "permissions": details.permissions,
                 "breadcrumbs": details.breadcrumbs,
+                "dataset_categories": details.dataset_categories,
+                "workflow_stages": details.workflow_stages,
+                "filter_media_types_datalist": details.filter_media_types_datalist,
+                "current_temporal_extent": details.current_temporal_extent,
             },
         )
 
@@ -1198,6 +1242,9 @@ async def _count_bulk_update_matches(
         spatial_intersect=selection.spatial_intersect,
         temporal_extent=selection.temporal_extent,
         asset_path_fragment_filter=selection.asset_path_fragment_filter,
+        asset_media_type_filter=selection.asset_media_type_filter,
+        dataset_category_id=selection.dataset_category_id,
+        workflow_stage_id=selection.workflow_stage_id,
         record_ids=selection.selected,
         excluded_record_ids=selection.excluded_record_ids,
     )

--- a/src/seis_lab_data/webapp/templates/macros.html
+++ b/src/seis_lab_data/webapp/templates/macros.html
@@ -175,7 +175,7 @@ Object.keys($excludedIds).forEach((k) => { $excludedIds[k] = false });
     extra_on_input_js=""
 ) %}
     <div class="mb-3">
-        <label for="search-temporal-extent-begin">{{ begin_label_text }}</label>
+        <label class="form-label" for="search-temporal-extent-begin">{{ begin_label_text }}</label>
         <input
                 id="search-temporal-extent-begin"
                 class="form-control" type="date"
@@ -185,7 +185,7 @@ Object.keys($excludedIds).forEach((k) => { $excludedIds[k] = false });
         >
     </div>
     <div class="mb-3">
-        <label for="search-temporal-extent-end">{{ end_label_text }}</label>
+        <label class="form-label" for="search-temporal-extent-end">{{ end_label_text }}</label>
         <input
                 id="search-temporal-extent-end"
                 class="form-control"

--- a/src/seis_lab_data/webapp/templates/projects/list.html
+++ b/src/seis_lab_data/webapp/templates/projects/list.html
@@ -93,8 +93,8 @@ Users with create permission are linked to /projects/new, which is a separate st
                                 url_for("projects:get_list_component"),
                                 _("Temporal extent begin"),
                                 _("Temporal extent end"),
-                                "{{ current_temporal_extent.begin }}",
-                                "{{ current_temporal_extent.end }}"
+                                current_temporal_extent.begin,
+                                current_temporal_extent.end
                             ) }}
                         </div>
                         <div

--- a/src/seis_lab_data/webapp/templates/survey-missions/detail-component.html
+++ b/src/seis_lab_data/webapp/templates/survey-missions/detail-component.html
@@ -2,7 +2,9 @@
 {% import "macros-buttons.html" as macros_buttons %}
 {% import "macros-buttons-list-items.html" as macros_buttons_list_items %}
 {% import "macros-maps.html" as macros_maps %}
-{% from "macros/search.html" import search_component %}
+{% from "macros/checkbox.html" import search_checkbox %}
+{% from "macros/select.html" import search_select %}
+{% from "macros/datalist.html" import search_datalist %}
 <div
         class="row"
         data-on-intersect__once="@get('{{ url_for("survey_missions:detail_stream", request_id=request_id, survey_mission_id=item.id) }}')"
@@ -73,6 +75,9 @@
         </div>
         <div
             class="row mt-4"
+            data-signals:search="'{{ search_initial_value | default('', true) }}'"
+            data-signals:advanced-search-panel-open="false"
+            data-signals:searching="false"
             data-signals:listing-version="0"
             data-signals:selected-ids="{}"
             data-signals:excluded-ids="{}"
@@ -81,12 +86,107 @@
         >
             <div class="col">
                 <h2>{{ _("survey-related-records") | capitalize }}</h2>
-                {{ search_component(
-                   url_for("survey_missions:get_mission_records_list_component", survey_mission_id=item.id),
-                   _("search survey-related records"),
-                   initial_value=search_initial_value | default("", true),
-                   extra_on_input_js=macros.reset_selection_js()
-                ) }}
+                {% set mission_records_url = url_for("survey_missions:get_mission_records_list_component", survey_mission_id=item.id) %}
+                <div class="row justify-content-center mb-3">
+                    <div class="col-8">
+                        <search class="form-floating">
+                            <input
+                                    class="form-control form-control-lg"
+                                    type="search"
+                                    id="search"
+                                    placeholder="Search"
+                                    data-bind:search
+                                    data-on:input__debounce.200ms="{{ macros.reset_selection_js() }}@get('{{ mission_records_url }}')"
+                                    data-indicator:searching
+                            />
+                            <label class="form-label" for="search">
+                                <span class="material-icons-outlined">{{ icons.search }}</span>
+                                {{ _("search survey-related records") | capitalize }}
+                            </label>
+                        </search>
+                        {{ search_checkbox(
+                                "search-only-internal",
+                                "false",
+                                "filterOnlyInternal",
+                                mission_records_url,
+                                _("show only internal survey-related records") | capitalize
+                            ) }}
+                        <div
+                                data-attr:hidden="!$searching"
+                                class="spinner-border spinner-border-sm ms-3"
+                                role="status"
+                                aria-hidden="true"
+                        >
+                            <span class="visually-hidden">{{ _("searching...") | capitalize }}</span>
+                        </div>
+                        <button
+                                class="btn btn-light btn-sm mt-1"
+                                type="button"
+                                data-on:click="$advancedSearchPanelOpen=!$advancedSearchPanelOpen"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#mission-advanced-search-controls"
+                                aria-expanded="false"
+                                aria-controls="mission-advanced-search-controls"
+                        >
+                            <span
+                                    class="material-icons-outlined me-1"
+                                    data-attr:style="$advancedSearchPanelOpen ? 'transform: rotate(0deg); transition: transform 0.3s ease;' : 'transform: rotate(-90deg); transition: transform 0.3s ease;'"
+                            >
+                                {{ icons.expand_more }}
+                            </span>
+                            {{ _("toggle advanced search controls") | capitalize }}
+                        </button>
+                    </div>
+                </div>
+                <div class="row collapse" id="mission-advanced-search-controls">
+                    <div class="col-6">
+                        {{ search_select(
+                            "search-dataset-category",
+                            dataset_categories,
+                                "filterDatasetCategory",
+                                mission_records_url,
+                                _("dataset category") | capitalize
+                        ) }}
+                        {{ search_select(
+                            "search-workflow-stage",
+                            workflow_stages,
+                                "filterWorkflowStage",
+                                mission_records_url,
+                                _("workflow stage") | capitalize
+                        ) }}
+                        {{ search_datalist(
+                              "search-asset-media-type",
+                              filter_media_types_datalist,
+                              "filterMediaType",
+                              mission_records_url,
+                              _("media type") | capitalize
+                        ) }}
+                    </div>
+                    <div class="col-6">
+                        <div class="row">
+                            <div class="col">
+                                {{ macros.render_temporal_extent_search_component(
+                                                mission_records_url,
+                                                _("Temporal extent begin"),
+                                                _("Temporal extent end"),
+                                                current_temporal_extent.begin,
+                                                current_temporal_extent.end,
+                                                extra_on_input_js=macros.reset_selection_js()
+                                            ) }}
+                                <div class="mb-3">
+                                    <label class="form-label" for="path-fragment">{{ _("Path") }}</label>
+                                    <input
+                                            id="path-fragment"
+                                            class="form-control"
+                                            data-bind="assetPathFragment"
+                                            data-on:input__debounce.200ms="{{ macros.reset_selection_js() }}@get('{{ mission_records_url }}')"
+                                            value=""
+                                    >
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div id="survey-mission-records">
                     {% with items = survey_related_records, bulk_update_base_url = (url_for("survey_missions:get_bulk_update_form", survey_mission_id=item.id) if permissions.can_bulk_update else none) %}
                         {% include "survey-related-records/list-component.html" %}

--- a/src/seis_lab_data/webapp/templates/survey-missions/list.html
+++ b/src/seis_lab_data/webapp/templates/survey-missions/list.html
@@ -93,8 +93,8 @@
                                         url_for("survey_missions:get_list_component"),
                                         _("Temporal extent begin"),
                                         _("Temporal extent end"),
-                                        "{{ current_temporal_extent.begin }}",
-                                        "{{ current_temporal_extent.end }}"
+                                        current_temporal_extent.begin,
+                                        current_temporal_extent.end
                                     ) }}
                         </div>
                         <div

--- a/src/seis_lab_data/webapp/templates/survey-related-records/list-component.html
+++ b/src/seis_lab_data/webapp/templates/survey-related-records/list-component.html
@@ -52,7 +52,7 @@
                         <div
                                 class="col-auto"
                                 data-attr:hidden="$selectedCount === 0"
-                                data-computed:bulk-update-url="'{{ bulk_update_base_url }}?selection=' + encodeURIComponent(JSON.stringify({search: $search, selectedIds: $selectedIds, excludedIds: $excludedIds, selectAllMatching: $selectAllMatching}))"
+                                data-computed:bulk-update-url="'{{ bulk_update_base_url }}?selection=' + encodeURIComponent(JSON.stringify({search: $search, selectedIds: $selectedIds, excludedIds: $excludedIds, selectAllMatching: $selectAllMatching, filterDatasetCategory: $filterDatasetCategory, filterWorkflowStage: $filterWorkflowStage, filterMediaType: $filterMediaType, temporalExtentBegin: $temporalExtentBegin, temporalExtentEnd: $temporalExtentEnd, assetPathFragment: $assetPathFragment}))"
                         >
                             <a
                                     class="btn btn-primary btn-sm"

--- a/src/seis_lab_data/webapp/templates/survey-related-records/list.html
+++ b/src/seis_lab_data/webapp/templates/survey-related-records/list.html
@@ -133,12 +133,12 @@
                                         url_for("survey_related_records:get_list_component"),
                                         _("Temporal extent begin"),
                                         _("Temporal extent end"),
-                                        "{{ current_temporal_extent.begin }}",
-                                        "{{ current_temporal_extent.end }}",
+                                        current_temporal_extent.begin,
+                                        current_temporal_extent.end,
                                         extra_on_input_js=macros.reset_selection_js()
                                     ) }}
                         <div class="mb-3">
-                            <label for="path-fragment">{{ _("Path") }}</label>
+                            <label class="form-label" for="path-fragment">{{ _("Path") }}</label>
                             <input
                                     id="path-fragment"
                                     class="form-control"

--- a/tests/test_operations_surveyrelatedrecords.py
+++ b/tests/test_operations_surveyrelatedrecords.py
@@ -117,6 +117,97 @@ async def test_bulk_update_admin_bypasses_ownership_restriction(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_bulk_update_workflow_stage_filter_excludes_non_matching_records(
+    db,
+    db_session_maker,
+    sample_survey_related_records,
+    bootstrap_workflow_stages,
+    admin_user,
+):
+    # sample records are all in the "raw data" workflow stage, not this one
+    non_matching_stage = [
+        w for w in bootstrap_workflow_stages if w.name["en"] == "quality control data"
+    ][0]
+    to_update = record_schemas.SurveyRelatedRecordBulkUpdate(
+        description=common_schemas.LocalizableDraftDescription(en="Should not apply")
+    )
+    dispatcher = _EventCollector()
+    async with db_session_maker() as session:
+        result = await record_ops.bulk_update_survey_related_records(
+            request_id=RequestId(uuid.uuid4()),
+            to_update=to_update,
+            initiator=admin_user,
+            session=session,
+            event_dispatcher=dispatcher,
+            workflow_stage_id=identifiers.WorkflowStageId(non_matching_stage.id),
+        )
+    assert result == 0
+    assert dispatcher.events[0].succeeded is True
+    assert dispatcher.events[0].affected_count == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_bulk_update_dataset_category_filter_combines_with_name_filter(
+    db,
+    db_session_maker,
+    sample_survey_related_records,
+    bootstrap_dataset_categories,
+    admin_user,
+):
+    # both sample records are in "bathymetry", so this narrows only via en_name_filter
+    matching_category = [
+        c for c in bootstrap_dataset_categories if c.name["en"] == "bathymetry"
+    ][0]
+    to_update = record_schemas.SurveyRelatedRecordBulkUpdate(
+        description=common_schemas.LocalizableDraftDescription(en="Should apply")
+    )
+    dispatcher = _EventCollector()
+    async with db_session_maker() as session:
+        result = await record_ops.bulk_update_survey_related_records(
+            request_id=RequestId(uuid.uuid4()),
+            to_update=to_update,
+            initiator=admin_user,
+            session=session,
+            event_dispatcher=dispatcher,
+            en_name_filter="First",
+            dataset_category_id=identifiers.DatasetCategoryId(matching_category.id),
+        )
+    assert result == 1
+    assert dispatcher.events[0].succeeded is True
+    assert dispatcher.events[0].affected_count == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_bulk_update_asset_media_type_filter_excludes_non_matching_records(
+    db,
+    db_session_maker,
+    sample_survey_related_records,
+    admin_user,
+):
+    # sample record assets don't have a media_type set, so any filter value excludes them
+    to_update = record_schemas.SurveyRelatedRecordBulkUpdate(
+        description=common_schemas.LocalizableDraftDescription(en="Should not apply")
+    )
+    dispatcher = _EventCollector()
+    async with db_session_maker() as session:
+        result = await record_ops.bulk_update_survey_related_records(
+            request_id=RequestId(uuid.uuid4()),
+            to_update=to_update,
+            initiator=admin_user,
+            session=session,
+            event_dispatcher=dispatcher,
+            en_name_filter="First",
+            asset_media_type_filter="video/mp4",
+        )
+    assert result == 0
+    assert dispatcher.events[0].succeeded is True
+    assert dispatcher.events[0].affected_count == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_bulk_update_manually_selected_records_via_operation(
     db,
     db_session_maker,


### PR DESCRIPTION
This PR continues implementing the search filters discussed in #161.

It focuses on adding search filters to the survey mission detail page, making it easier to select relevant records and then perform bulk actions on them.