### PR TITLE
fixed temporal extent not accounting for none

### DIFF
--- a/src/seis_lab_data/db/queries/projects.py
+++ b/src/seis_lab_data/db/queries/projects.py
@@ -47,11 +47,17 @@ def _build_project_statement(
     if temporal_extent is not None:
         if temporal_extent.begin is not None:
             statement = statement.where(
-                models.Project.temporal_extent_begin >= temporal_extent.begin
+                or_(
+                    models.Project.temporal_extent_begin >= temporal_extent.begin,
+                    models.Project.temporal_extent_begin.is_(None),
+                )
             )
         if temporal_extent.end is not None:
             statement = statement.where(
-                models.Project.temporal_extent_end <= temporal_extent.end
+                or_(
+                    models.Project.temporal_extent_end <= temporal_extent.end,
+                    models.Project.temporal_extent_end.is_(None),
+                )
             )
     return statement.order_by(
         models.Project.temporal_extent_end.desc().nullslast()

--- a/src/seis_lab_data/db/queries/surveymissions.py
+++ b/src/seis_lab_data/db/queries/surveymissions.py
@@ -49,11 +49,17 @@ def _build_survey_mission_statement(
     if temporal_extent is not None:
         if temporal_extent.begin is not None:
             statement = statement.where(
-                models.SurveyMission.temporal_extent_begin >= temporal_extent.begin
+                or_(
+                    models.SurveyMission.temporal_extent_begin >= temporal_extent.begin,
+                    models.SurveyMission.temporal_extent_begin.is_(None),
+                )
             )
         if temporal_extent.end is not None:
             statement = statement.where(
-                models.SurveyMission.temporal_extent_end <= temporal_extent.end
+                or_(
+                    models.SurveyMission.temporal_extent_end <= temporal_extent.end,
+                    models.SurveyMission.temporal_extent_end.is_(None),
+                )
             )
     return statement.order_by(
         models.SurveyMission.temporal_extent_end.desc().nullslast()

--- a/src/seis_lab_data/db/queries/surveyrelatedrecords.py
+++ b/src/seis_lab_data/db/queries/surveyrelatedrecords.py
@@ -75,12 +75,19 @@ def _apply_survey_related_record_filters(
     if temporal_extent is not None:
         if temporal_extent.begin is not None:
             statement = statement.where(
-                models.SurveyRelatedRecord.temporal_extent_begin
-                >= temporal_extent.begin
+                or_(
+                    models.SurveyRelatedRecord.temporal_extent_begin
+                    >= temporal_extent.begin,
+                    models.SurveyRelatedRecord.temporal_extent_begin.is_(None),
+                )
             )
         if temporal_extent.end is not None:
             statement = statement.where(
-                models.SurveyRelatedRecord.temporal_extent_end <= temporal_extent.end
+                or_(
+                    models.SurveyRelatedRecord.temporal_extent_end
+                    <= temporal_extent.end,
+                    models.SurveyRelatedRecord.temporal_extent_end.is_(None),
+                )
             )
     if dataset_category_id is not None:
         statement = statement.where(


### PR DESCRIPTION
This PR modifies DB queries that filter with a temporal extent to also include items if they do not have a temporal extent

---

- fixes #179