### PR TITLE
simplify access controls

### DIFF
--- a/src/seis_lab_data/db/commands/surveyrelatedrecords.py
+++ b/src/seis_lab_data/db/commands/surveyrelatedrecords.py
@@ -191,18 +191,11 @@ async def bulk_update_manually_selected_records(
     session: AsyncSession,
     to_update: record_schemas.SurveyRelatedRecordBulkUpdate,
     selected: list[identifiers.SurveyRelatedRecordId],
-    user_id: identifiers.UserId,
-    restrict_to_owned: bool = True,
     survey_mission_id: identifiers.SurveyMissionId | None = None,
 ) -> int:
-    if restrict_to_owned:
-        ids_statement = record_queries.build_owned_survey_related_record_id_statement(
-            user_id, survey_mission_id=survey_mission_id, record_ids=selected
-        )
-    else:
-        ids_statement = record_queries.build_survey_related_record_id_statement(
-            survey_mission_id=survey_mission_id, record_ids=selected
-        )
+    ids_statement = record_queries.build_survey_related_record_id_statement(
+        survey_mission_id=survey_mission_id, record_ids=selected
+    )
     matched_ids = (await session.exec(ids_statement)).all()
     try:
         updated_count = await _apply_bulk_update_to_matched_records(
@@ -218,8 +211,6 @@ async def bulk_update_manually_selected_records(
 async def bulk_update_filtered_records(
     session: AsyncSession,
     to_update: record_schemas.SurveyRelatedRecordBulkUpdate,
-    user_id: identifiers.UserId,
-    restrict_to_owned: bool = True,
     excluded_record_ids: list[identifiers.SurveyRelatedRecordId] | None = None,
     survey_mission_id: identifiers.SurveyMissionId | None = None,
     en_name_filter: str | None = None,
@@ -243,14 +234,9 @@ async def bulk_update_filtered_records(
         workflow_stage_id=workflow_stage_id,
         excluded_record_ids=excluded_record_ids,
     )
-    if restrict_to_owned:
-        ids_statement = record_queries.build_owned_survey_related_record_id_statement(
-            user_id, **filter_kwargs
-        )
-    else:
-        ids_statement = record_queries.build_survey_related_record_id_statement(
-            **filter_kwargs
-        )
+    ids_statement = record_queries.build_survey_related_record_id_statement(
+        **filter_kwargs
+    )
     matched_ids = (await session.exec(ids_statement)).all()
     try:
         updated_count = await _apply_bulk_update_to_matched_records(

--- a/src/seis_lab_data/db/queries/projects.py
+++ b/src/seis_lab_data/db/queries/projects.py
@@ -88,35 +88,10 @@ async def list_published_projects(
     spatial_intersect: shapely.Polygon | None = None,
     temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
 ) -> tuple[list[models.Project], int | None]:
-    """Lists public projects."""
+    """Produces a paginated and filterable listing of public projects."""
     statement = _build_project_statement(
         en_name_filter, pt_name_filter, spatial_intersect, temporal_extent
     ).where(models.Project.status == ProjectStatus.PUBLISHED)
-    limit = page_size
-    offset = page_size * (page - 1)
-    return await _exec_project_list(session, statement, limit, offset, include_total)
-
-
-async def list_accessible_projects(
-    session: AsyncSession,
-    user_id: str,
-    page: int = 1,
-    page_size: int = 20,
-    include_total: bool = False,
-    en_name_filter: str | None = None,
-    pt_name_filter: str | None = None,
-    spatial_intersect: shapely.Polygon | None = None,
-    temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
-) -> tuple[list[models.Project], int | None]:
-    """List projects that are viewable by the input user."""
-    statement = _build_project_statement(
-        en_name_filter, pt_name_filter, spatial_intersect, temporal_extent
-    ).where(
-        or_(
-            models.Project.status == ProjectStatus.PUBLISHED,
-            models.Project.owner_id == user_id,
-        )
-    )
     limit = page_size
     offset = page_size * (page - 1)
     return await _exec_project_list(session, statement, limit, offset, include_total)
@@ -133,7 +108,10 @@ async def list_projects(
     temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
     only_internal: bool = False,
 ) -> tuple[list[models.Project], int | None]:
-    """Return all projects. Intended for admin use."""
+    """Produces a paginated and filterable listing of all projects.
+
+    Intended for registered users.
+    """
     statement = _build_project_statement(
         en_name_filter, pt_name_filter, spatial_intersect, temporal_extent
     )

--- a/src/seis_lab_data/db/queries/surveymissions.py
+++ b/src/seis_lab_data/db/queries/surveymissions.py
@@ -101,42 +101,6 @@ async def list_published_survey_missions(
     )
 
 
-async def list_accessible_survey_missions(
-    session: AsyncSession,
-    user_id: str,
-    project_id: identifiers.ProjectId | None = None,
-    page: int = 1,
-    page_size: int = 20,
-    include_total: bool = False,
-    en_name_filter: str | None = None,
-    pt_name_filter: str | None = None,
-    spatial_intersect: shapely.Polygon | None = None,
-    temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
-) -> tuple[list[models.SurveyMission], int | None]:
-    statement = (
-        _build_survey_mission_statement(
-            project_id,
-            en_name_filter,
-            pt_name_filter,
-            spatial_intersect,
-            temporal_extent,
-        )
-        .join(models.Project, models.SurveyMission.project_id == models.Project.id)
-        .where(
-            or_(
-                models.SurveyMission.status == SurveyMissionStatus.PUBLISHED,
-                models.SurveyMission.owner_id == user_id,
-                models.Project.owner_id == user_id,
-            )
-        )
-    )
-    limit = page_size
-    offset = page_size * (page - 1)
-    return await _exec_survey_mission_list(
-        session, statement, limit, offset, include_total
-    )
-
-
 async def list_survey_missions(
     session: AsyncSession,
     project_id: identifiers.ProjectId | None = None,

--- a/src/seis_lab_data/db/queries/surveyrelatedrecords.py
+++ b/src/seis_lab_data/db/queries/surveyrelatedrecords.py
@@ -258,95 +258,6 @@ async def list_published_survey_related_records(
     )
 
 
-def _restrict_to_accessible(statement, user_id: str):
-    """Restrict a survey-related record statement to records a user may see.
-
-    A record is accessible if it is published, or if the user owns the
-    record itself, its survey mission, or its project.
-    """
-    return (
-        statement.join(
-            models.SurveyMission,
-            models.SurveyRelatedRecord.survey_mission_id == models.SurveyMission.id,
-        )
-        .join(models.Project, models.SurveyMission.project_id == models.Project.id)
-        .where(
-            or_(
-                models.SurveyRelatedRecord.status
-                == SurveyRelatedRecordStatus.PUBLISHED,
-                models.SurveyRelatedRecord.owner_id == user_id,
-                models.SurveyMission.owner_id == user_id,
-                models.Project.owner_id == user_id,
-            )
-        )
-    )
-
-
-async def list_accessible_survey_related_records(
-    session: AsyncSession,
-    user_id: str,
-    survey_mission_id: identifiers.SurveyMissionId | None = None,
-    project_id: identifiers.ProjectId | None = None,
-    page: int = 1,
-    page_size: int = 20,
-    include_total: bool = False,
-    en_name_filter: str | None = None,
-    pt_name_filter: str | None = None,
-    spatial_intersect: shapely.Polygon | None = None,
-    temporal_extent: filter_schemas.TemporalExtentFilterValue | None = None,
-    asset_path_fragment_filter: str | None = None,
-    asset_media_type_filter: str | None = None,
-    record_ids: list[identifiers.SurveyRelatedRecordId] | None = None,
-    dataset_category_id: identifiers.DatasetCategoryId | None = None,
-    workflow_stage_id: identifiers.WorkflowStageId | None = None,
-) -> tuple[list[models.SurveyRelatedRecord], int | None]:
-    statement = _restrict_to_accessible(
-        _build_survey_related_record_statement(
-            survey_mission_id=survey_mission_id,
-            project_id=project_id,
-            en_name_filter=en_name_filter,
-            pt_name_filter=pt_name_filter,
-            spatial_intersect=spatial_intersect,
-            temporal_extent=temporal_extent,
-            asset_path_fragment_filter=asset_path_fragment_filter,
-            asset_media_type_filter=asset_media_type_filter,
-            record_ids=record_ids,
-            dataset_category_id=dataset_category_id,
-            workflow_stage_id=workflow_stage_id,
-        ),
-        user_id,
-    )
-    limit = page_size
-    offset = page_size * (page - 1)
-    return await _exec_survey_related_record_list(
-        session, statement, limit, offset, include_total
-    )
-
-
-def _restrict_to_owned(statement, user_id: str):
-    """Restrict a survey-related record statement to records a user owns.
-
-    A record is owned if the user owns the record itself, its survey
-    mission, or its project. Unlike `_restrict_to_accessible`, published
-    status does not grant access here - this is for edit authorization
-    (mirroring `can_update_survey_related_record`), not read visibility.
-    """
-    return (
-        statement.join(
-            models.SurveyMission,
-            models.SurveyRelatedRecord.survey_mission_id == models.SurveyMission.id,
-        )
-        .join(models.Project, models.SurveyMission.project_id == models.Project.id)
-        .where(
-            or_(
-                models.SurveyRelatedRecord.owner_id == user_id,
-                models.SurveyMission.owner_id == user_id,
-                models.Project.owner_id == user_id,
-            )
-        )
-    )
-
-
 def build_survey_related_record_id_statement(
     survey_mission_id: identifiers.SurveyMissionId | None = None,
     en_name_filter: str | None = None,
@@ -384,7 +295,6 @@ def build_survey_related_record_id_statement(
 
 
 def build_owned_survey_related_record_id_statement(
-    user_id: str,
     survey_mission_id: identifiers.SurveyMissionId | None = None,
     en_name_filter: str | None = None,
     pt_name_filter: str | None = None,
@@ -402,20 +312,17 @@ def build_owned_survey_related_record_id_statement(
     Intended for non-admin editors, who may only bulk-update records they
     own, or whose survey mission or project they own.
     """
-    statement = _restrict_to_owned(
-        _build_survey_related_record_id_statement(
-            survey_mission_id,
-            en_name_filter,
-            pt_name_filter,
-            spatial_intersect,
-            temporal_extent,
-            asset_path_fragment_filter,
-            asset_media_type_filter,
-            record_ids,
-            dataset_category_id,
-            workflow_stage_id,
-        ),
-        user_id,
+    statement = _build_survey_related_record_id_statement(
+        survey_mission_id,
+        en_name_filter,
+        pt_name_filter,
+        spatial_intersect,
+        temporal_extent,
+        asset_path_fragment_filter,
+        asset_media_type_filter,
+        record_ids,
+        dataset_category_id,
+        workflow_stage_id,
     )
     if excluded_record_ids:
         statement = statement.where(

--- a/src/seis_lab_data/errors.py
+++ b/src/seis_lab_data/errors.py
@@ -1,2 +1,6 @@
 class SeisLabDataError(Exception):
     pass
+
+
+class UserNotAllowedError(SeisLabDataError):
+    pass

--- a/src/seis_lab_data/operations/projects.py
+++ b/src/seis_lab_data/operations/projects.py
@@ -418,15 +418,9 @@ async def list_projects(
     )
     if initiator is None:
         return await project_queries.list_published_projects(session, **kwargs)
-    elif not {constants.ROLE_ADMIN, constants.ROLE_SYSTEM_ADMIN}.isdisjoint(
-        initiator.roles
-    ):
+    else:
         kwargs.update(only_internal=only_internal)
         return await project_queries.list_projects(session, **kwargs)
-    else:
-        return await project_queries.list_accessible_projects(
-            session, initiator.id, **kwargs
-        )
 
 
 async def get_project(
@@ -437,8 +431,18 @@ async def get_project(
     project = await project_queries.get_project(session, project_id)
     if project is None:
         return None
-    if not project_permissions.can_read_project(initiator, project):
-        raise errors.SeisLabDataError(
+
+    if project.status == constants.ProjectStatus.PUBLISHED:
+        return project
+
+    if initiator is None:
+        raise errors.UserNotAllowedError(
+            f"User not allowed to read project {project_id!r}."
+        )
+
+    if not project_permissions.can_read_private_project(initiator, project):
+        raise errors.UserNotAllowedError(
             f"User is not allowed to read project {project_id!r}."
         )
+
     return project

--- a/src/seis_lab_data/operations/surveymissions.py
+++ b/src/seis_lab_data/operations/surveymissions.py
@@ -442,15 +442,9 @@ async def list_survey_missions(
     )
     if initiator is None:
         return await mission_queries.list_published_survey_missions(session, **kwargs)
-    elif not {constants.ROLE_ADMIN, constants.ROLE_SYSTEM_ADMIN}.isdisjoint(
-        initiator.roles
-    ):
+    else:
         kwargs.update(only_internal=only_internal)
         return await mission_queries.list_survey_missions(session, **kwargs)
-    else:
-        return await mission_queries.list_accessible_survey_missions(
-            session, initiator.id, **kwargs
-        )
 
 
 async def get_survey_mission(
@@ -461,8 +455,15 @@ async def get_survey_mission(
     mission = await mission_queries.get_survey_mission(session, survey_mission_id)
     if mission is None:
         return None
-    if not mission_permissions.can_read_survey_mission(initiator, mission):
-        raise errors.SeisLabDataError(
-            f"User is not allowed to read survey mission {survey_mission_id!r}."
-        )
+
+    if mission.status == constants.SurveyMissionStatus.PUBLISHED:
+        return mission
+
+    error_msg = f"User not allowed to read survey mission {survey_mission_id!r}."
+
+    if initiator is None:
+        raise errors.UserNotAllowedError(error_msg)
+
+    if not mission_permissions.can_read_private_survey_mission(initiator, mission):
+        raise errors.UserNotAllowedError(error_msg)
     return mission

--- a/src/seis_lab_data/operations/surveyrelatedrecords.py
+++ b/src/seis_lab_data/operations/surveyrelatedrecords.py
@@ -370,15 +370,9 @@ async def list_survey_related_records(
         return await record_queries.list_published_survey_related_records(
             session, **kwargs
         )
-    elif not {constants.ROLE_ADMIN, constants.ROLE_SYSTEM_ADMIN}.isdisjoint(
-        initiator.roles
-    ):
+    else:
         kwargs.update(only_internal=only_internal)
         return await record_queries.list_survey_related_records(session, **kwargs)
-    else:
-        return await record_queries.list_accessible_survey_related_records(
-            session, initiator.id, **kwargs
-        )
 
 
 async def get_survey_related_record(
@@ -398,11 +392,7 @@ async def get_survey_related_record(
     )
     if record is None:
         return None
-    if not record_permissions.can_read_survey_related_record(initiator, record):
-        raise errors.SeisLabDataError(
-            f"User is not allowed to read survey-related "
-            f"record {survey_related_record_id!r}."
-        )
+
     record_id = identifiers.SurveyRelatedRecordId(record.id)
     records_related_to = (
         await record_queries.list_survey_related_record_related_to_records(
@@ -414,6 +404,18 @@ async def get_survey_related_record(
             session, record_id
         )
     )
+
+    if record.status == constants.SurveyRelatedRecordStatus.PUBLISHED:
+        return record, records_related_to, records_subject_for
+
+    error_msg = f"User not allowed to read survey-related record {record_id!r}."
+
+    if initiator is None:
+        raise errors.UserNotAllowedError(error_msg)
+
+    if not record_permissions.can_read_private_survey_related_record(initiator, record):
+        raise errors.UserNotAllowedError(error_msg)
+
     return record, records_related_to, records_subject_for
 
 
@@ -522,29 +524,22 @@ async def bulk_update_survey_related_records(
     `survey_mission_id` is an optional additional scope - omit it to bulk-update
     across all missions a user may access.
     """
-    is_admin = not {constants.ROLE_ADMIN, constants.ROLE_SYSTEM_ADMIN}.isdisjoint(
-        initiator.roles
-    )
     try:
         if not record_permissions.can_bulk_update_survey_related_records(initiator):
-            raise errors.SeisLabDataError(
-                "User is not allowed to bulk-update survey-related records."
+            raise errors.UserNotAllowedError(
+                "User not allowed to bulk-update survey-related records."
             )
         if selected is not None:
             updated_count = await record_commands.bulk_update_manually_selected_records(
                 session,
                 to_update,
                 selected,
-                identifiers.UserId(initiator.id),
-                restrict_to_owned=not is_admin,
                 survey_mission_id=survey_mission_id,
             )
         else:
             updated_count = await record_commands.bulk_update_filtered_records(
                 session,
                 to_update,
-                identifiers.UserId(initiator.id),
-                restrict_to_owned=not is_admin,
                 excluded_record_ids=excluded_record_ids,
                 survey_mission_id=survey_mission_id,
                 en_name_filter=en_name_filter,

--- a/src/seis_lab_data/permissions/common.py
+++ b/src/seis_lab_data/permissions/common.py
@@ -1,0 +1,18 @@
+from ..schemas.user import User
+from .. import constants
+
+
+def is_editor(*user_role: str) -> bool:
+    return not {
+        constants.ROLE_SYSTEM_ADMIN,
+        constants.ROLE_ADMIN,
+        constants.ROLE_EDITOR,
+    }.isdisjoint(user_role)
+
+
+def can_manage_item(
+    user: User | None,
+) -> bool:
+    if user is None:
+        return False
+    return is_editor(*user.roles)

--- a/src/seis_lab_data/permissions/projects.py
+++ b/src/seis_lab_data/permissions/projects.py
@@ -1,75 +1,56 @@
 import logging
 
-from ..schemas.user import User
-from ..constants import (
-    ROLE_ADMIN,
-    ROLE_EDITOR,
-    ROLE_SYSTEM_ADMIN,
-    ProjectStatus,
-)
 from ..db import models
+from ..schemas.user import User
+
+from .common import can_manage_item
 
 logger = logging.getLogger(__name__)
 
 
-def can_read_project(
+def can_read_private_project(
     user: User | None,
     project: models.Project,
 ) -> bool:
-    if user and not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    if project.status == ProjectStatus.PUBLISHED:
-        return True
-    return user is not None and project.owner_id == user.id
+    return user is not None
 
 
 def can_create_project(
     user: User | None,
 ) -> bool:
-    if user is None:
-        return False
-    if not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN, ROLE_EDITOR}.isdisjoint(user.roles):
-        return True
-    else:
-        return False
+    return can_manage_item(user)
 
 
 def can_update_project(
     user: User | None,
     project: models.Project,
 ) -> bool:
-    if not user:
-        return False
-    if not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    if ROLE_EDITOR in user.roles and project.owner_id == user.id:
-        return True
-    return False
+    return can_manage_item(user)
 
 
 def can_delete_project(
     user: User | None,
     project: models.Project,
 ) -> bool:
-    return can_update_project(user, project)
+    return can_manage_item(user)
 
 
 def can_validate_project(
     user: User | None,
     project: models.Project,
 ) -> bool:
-    return can_update_project(user, project)
+    return can_manage_item(user)
 
 
 def can_change_project_status(
     user: User | None,
     project: models.Project,
 ) -> bool:
-    return can_update_project(user, project)
+    return can_manage_item(user)
 
 
 def can_discover_project(
     user: User | None,
     project: models.Project,
 ) -> bool:
-    return can_update_project(user, project)
+    return can_manage_item(user)

--- a/src/seis_lab_data/permissions/surveymissions.py
+++ b/src/seis_lab_data/permissions/surveymissions.py
@@ -1,76 +1,54 @@
 import logging
 
 from ..schemas.user import User
-from ..constants import (
-    ROLE_ADMIN,
-    ROLE_EDITOR,
-    ROLE_SYSTEM_ADMIN,
-    SurveyMissionStatus,
-)
 from ..db import models
+
+from .common import can_manage_item
 
 logger = logging.getLogger(__name__)
 
 
-def can_read_survey_mission(
+def can_read_private_survey_mission(
     user: User | None,
     mission: models.SurveyMission,
 ) -> bool:
-    if user and not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    if mission.status == SurveyMissionStatus.PUBLISHED:
-        return True
-    return user is not None and (
-        mission.owner_id == user.id or mission.project.owner_id == user.id
-    )
+    return user is not None
 
 
 def can_create_survey_mission(
     user: User | None,
     project: models.Project,
 ) -> bool:
-    if user is None:
-        return False
-    if not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    return ROLE_EDITOR in user.roles and project.owner_id == user.id
+    return can_manage_item(user)
 
 
 def can_update_survey_mission(
     user: User | None,
     mission: models.SurveyMission,
 ) -> bool:
-    if not user:
-        return False
-    if not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    if ROLE_EDITOR in user.roles and mission.owner_id == user.id:
-        return True
-    if ROLE_EDITOR in user.roles and mission.project.owner_id == user.id:
-        return True
-    return False
+    return can_manage_item(user)
 
 
 def can_delete_survey_mission(
     user: User | None,
     mission: models.SurveyMission,
 ) -> bool:
-    return can_update_survey_mission(user, mission)
+    return can_manage_item(user)
 
 
 def can_validate_survey_mission(
     user: User | None,
     mission: models.SurveyMission,
 ) -> bool:
-    return can_update_survey_mission(user, mission)
+    return can_manage_item(user)
 
 
 def can_discover_survey_mission(user: User, mission: models.SurveyMission) -> bool:
-    return can_update_survey_mission(user, mission)
+    return can_manage_item(user)
 
 
 def can_change_survey_mission_status(
     user: User | None,
     mission: models.SurveyMission,
 ) -> bool:
-    return can_update_survey_mission(user, mission)
+    return can_manage_item(user)

--- a/src/seis_lab_data/permissions/surveyrelatedrecords.py
+++ b/src/seis_lab_data/permissions/surveyrelatedrecords.py
@@ -1,96 +1,54 @@
 import logging
 
 from ..schemas.user import User
-from ..constants import (
-    ROLE_ADMIN,
-    ROLE_EDITOR,
-    ROLE_SYSTEM_ADMIN,
-    SurveyRelatedRecordStatus,
-)
 from ..db import models
+from .common import can_manage_item
 
 logger = logging.getLogger(__name__)
 
 
-def can_read_survey_related_record(
+def can_read_private_survey_related_record(
     user: User | None,
     record: models.SurveyRelatedRecord,
 ) -> bool:
-    if user and not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    if record.status == SurveyRelatedRecordStatus.PUBLISHED:
-        return True
-    if user and record.owner_id == user.id:
-        return True
-    if user and record.survey_mission.owner_id == user.id:
-        return True
-    if user and record.survey_mission.project.owner_id == user.id:
-        return True
-    return False
+    return user is not None
 
 
 def can_create_survey_related_record(
     user: User | None,
     mission: models.SurveyMission,
 ) -> bool:
-    if not user:
-        return False
-    if not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    if ROLE_EDITOR in user.roles and mission.owner_id == user.id:
-        return True
-    if ROLE_EDITOR in user.roles and mission.project.owner_id == user.id:
-        return True
-    return False
+    return can_manage_item(user)
 
 
 def can_update_survey_related_record(
     user: User | None,
     record: models.SurveyRelatedRecord,
 ) -> bool:
-    if not user:
-        return False
-    if not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    if ROLE_EDITOR in user.roles and record.owner_id == user.id:
-        return True
-    if ROLE_EDITOR in user.roles and record.survey_mission.owner_id == user.id:
-        return True
-    if ROLE_EDITOR in user.roles and record.survey_mission.project.owner_id == user.id:
-        return True
-    return False
+    return can_manage_item(user)
 
 
 def can_delete_survey_related_record(
     user: User | None,
     record: models.SurveyRelatedRecord,
 ) -> bool:
-    return can_update_survey_related_record(user, record)
+    return can_manage_item(user)
 
 
 def can_validate_survey_related_record(
     user: User | None,
     record: models.SurveyRelatedRecord,
 ) -> bool:
-    return can_update_survey_related_record(user, record)
+    return can_manage_item(user)
 
 
 def can_change_survey_related_record_status(
     user: User | None,
     record: models.SurveyRelatedRecord,
 ) -> bool:
-    return can_update_survey_related_record(user, record)
+    return can_manage_item(user)
 
 
 def can_bulk_update_survey_related_records(user: User) -> bool:
-    """Coarse-grained gate for attempting a bulk update.
-
-    Mirrors the role check in `can_update_survey_related_record`. Unlike
-    that function, this cannot also check per-record ownership, since bulk
-    updates are deliberately implemented without loading each record.
-    Ownership is instead enforced by scoping the underlying DB query to
-    owned records (or, for admins, leaving it unrestricted).
-    """
-    if not {ROLE_ADMIN, ROLE_SYSTEM_ADMIN}.isdisjoint(user.roles):
-        return True
-    return ROLE_EDITOR in user.roles
+    """Coarse-grained gate for attempting a bulk update."""
+    return can_manage_item(user)

--- a/src/seis_lab_data/schemas/projects.py
+++ b/src/seis_lab_data/schemas/projects.py
@@ -31,7 +31,6 @@ class ProjectCreate(pydantic.BaseModel):
 
 
 class ProjectUpdate(pydantic.BaseModel):
-    owner_id: UserId | None = None
     name: LocalizableDraftName | None = None
     description: LocalizableDraftDescription | None = None
     root_path: str | None = None
@@ -72,7 +71,6 @@ class ProjectReadListItem(ProjectReadEmbedded):
 
 
 class ProjectReadDetail(ProjectReadListItem):
-    owner_id: UserId
     links: list[LinkSchema] = []
     bbox_4326: PolygonOut | None
     # discovery_configuration: "ProjectDiscoveryConfiguration | None"

--- a/src/seis_lab_data/schemas/surveymissions.py
+++ b/src/seis_lab_data/schemas/surveymissions.py
@@ -36,7 +36,6 @@ class SurveyMissionCreate(pydantic.BaseModel):
 
 
 class SurveyMissionUpdate(pydantic.BaseModel):
-    owner_id: UserId | None = None
     project_id: ProjectId | None = None
     name: LocalizableDraftName | None = None
     description: LocalizableDraftDescription | None = None
@@ -100,7 +99,6 @@ class SurveyMissionReadListItem(pydantic.BaseModel):
 
 
 class SurveyMissionReadDetail(SurveyMissionReadListItem):
-    owner_id: UserId
     relative_path: str
     links: list[LinkSchema] = []
 

--- a/src/seis_lab_data/schemas/surveyrelatedrecords.py
+++ b/src/seis_lab_data/schemas/surveyrelatedrecords.py
@@ -165,7 +165,6 @@ class SurveyRelatedRecordBulkUpdateSelection(pydantic.BaseModel):
 
 
 class SurveyRelatedRecordUpdate(pydantic.BaseModel):
-    owner_id: UserId | None = None
     survey_mission_id: SurveyMissionId | None = None
 
     name: LocalizableDraftName | None = None
@@ -234,7 +233,6 @@ class SurveyRelatedRecordReadListItem(pydantic.BaseModel):
 
 
 class SurveyRelatedRecordReadDetail(SurveyRelatedRecordReadListItem):
-    owner_id: UserId
     links: list[LinkSchema] = []
     related_to_records: list[
         tuple[LocalizableDraftDescription, SurveyRelatedRecordReadEmbedded]

--- a/src/seis_lab_data/webapp/forms/projects.py
+++ b/src/seis_lab_data/webapp/forms/projects.py
@@ -195,7 +195,6 @@ class ProjectUpdateForm(_ProjectForm):
         discovery_configuration = self._parse_discovery_configuration()
         try:
             project_schemas.ProjectUpdate(
-                owner_id=None,
                 name={
                     **get_form_field_by_name(self, "name").data,
                 },

--- a/src/seis_lab_data/webapp/forms/surveymissions.py
+++ b/src/seis_lab_data/webapp/forms/surveymissions.py
@@ -186,7 +186,6 @@ class SurveyMissionUpdateForm(_SurveyMissionForm):
         try:
             survey_mission_schemas.SurveyMissionUpdate(
                 # these are not part of the form, but we must provide something
-                owner_id=None,
                 project_id=None,
                 name={
                     **get_form_field_by_name(self, "name").data,

--- a/src/seis_lab_data/webapp/forms/surveyrelatedrecords.py
+++ b/src/seis_lab_data/webapp/forms/surveyrelatedrecords.py
@@ -346,7 +346,6 @@ class SurveyRelatedRecordUpdateForm(_SurveyRelatedRecordForm):
         try:
             record_schemas.SurveyRelatedRecordUpdate(
                 # these are not part of the form, but we must provide something
-                owner_id=None,
                 survey_mission_id=None,
                 name={**get_form_field_by_name(self, "name").data},
                 description={**get_form_field_by_name(self, "description").data},

--- a/src/seis_lab_data/webapp/routes/projects.py
+++ b/src/seis_lab_data/webapp/routes/projects.py
@@ -407,23 +407,13 @@ async def _get_project_details(request: Request) -> webui_schemas.ProjectDetails
             ),
         ),
         permissions=webui_schemas.UserPermissionDetails(
-            can_delete=project_permissions.can_delete_project(user, project)
-            if user
-            else False,
-            can_update=project_permissions.can_update_project(user, project)
-            if user
-            else False,
+            can_delete=project_permissions.can_delete_project(user, project),
+            can_update=project_permissions.can_update_project(user, project),
             can_create_children=mission_permissions.can_create_survey_mission(
                 user, project
-            )
-            if user
-            else False,
-            can_validate=project_permissions.can_validate_project(user, project)
-            if user
-            else False,
-            can_discover=project_permissions.can_discover_project(user, project)
-            if user
-            else False,
+            ),
+            can_validate=project_permissions.can_validate_project(user, project),
+            can_discover=project_permissions.can_discover_project(user, project),
         ),
         breadcrumbs=[
             webui_schemas.BreadcrumbItem(

--- a/src/seis_lab_data/webapp/routes/surveymissions.py
+++ b/src/seis_lab_data/webapp/routes/surveymissions.py
@@ -168,33 +168,21 @@ async def _get_survey_mission_details(
         permissions=webui_schemas.UserPermissionDetails(
             can_create_children=record_permissions.can_create_survey_related_record(
                 user, survey_mission
-            )
-            if user
-            else False,
+            ),
             can_update=mission_permissions.can_update_survey_mission(
                 user, survey_mission
-            )
-            if user
-            else False,
+            ),
             can_delete=mission_permissions.can_delete_survey_mission(
                 user, survey_mission
-            )
-            if user
-            else False,
+            ),
             can_validate=mission_permissions.can_validate_survey_mission(
                 user, survey_mission
-            )
-            if user
-            else False,
+            ),
             can_discover=mission_permissions.can_discover_survey_mission(
                 user, survey_mission
-            )
-            if user
-            else False,
+            ),
             can_bulk_update=(
                 record_permissions.can_bulk_update_survey_related_records(user)
-                if user
-                else False
             ),
         ),
         breadcrumbs=[
@@ -1232,9 +1220,6 @@ def _parse_bulk_update_selection(
 async def _count_bulk_update_matches(
     session, user, selection: record_schemas.SurveyRelatedRecordBulkUpdateSelection
 ) -> int:
-    is_admin = not {constants.ROLE_ADMIN, constants.ROLE_SYSTEM_ADMIN}.isdisjoint(
-        user.roles
-    )
     kwargs = dict(
         survey_mission_id=selection.survey_mission_id,
         en_name_filter=selection.en_name_filter,
@@ -1248,12 +1233,7 @@ async def _count_bulk_update_matches(
         record_ids=selection.selected,
         excluded_record_ids=selection.excluded_record_ids,
     )
-    if is_admin:
-        statement = record_queries.build_survey_related_record_id_statement(**kwargs)
-    else:
-        statement = record_queries.build_owned_survey_related_record_id_statement(
-            user.id, **kwargs
-        )
+    statement = record_queries.build_survey_related_record_id_statement(**kwargs)
     return await record_queries.count_survey_related_records_matching(
         session, statement
     )

--- a/tests/test_db_commands.py
+++ b/tests/test_db_commands.py
@@ -333,7 +333,6 @@ async def test_bulk_update_filtered_records(
         updated_count = await record_commands.bulk_update_filtered_records(
             session,
             to_update,
-            identifiers.UserId(admin_user.id),
             en_name_filter="First",
         )
         assert updated_count == 1
@@ -367,7 +366,6 @@ async def test_bulk_update_filtered_records_excludes_records(
         updated_count = await record_commands.bulk_update_filtered_records(
             session,
             to_update,
-            identifiers.UserId(admin_user.id),
             excluded_record_ids=[identifiers.SurveyRelatedRecordId(first_record.id)],
         )
         assert updated_count == 1
@@ -400,7 +398,6 @@ async def test_bulk_update_manually_selected_records(
             session,
             to_update,
             [identifiers.SurveyRelatedRecordId(second_record.id)],
-            identifiers.UserId(admin_user.id),
         )
         assert updated_count == 1
         updated_second = await record_queries.get_survey_related_record(
@@ -438,7 +435,6 @@ async def test_bulk_update_manually_selected_records_replaces_related_records(
             session,
             add_relation,
             [identifiers.SurveyRelatedRecordId(second_record.id)],
-            identifiers.UserId(admin_user.id),
         )
         related_to = await record_queries.list_survey_related_record_related_to_records(
             session, identifiers.SurveyRelatedRecordId(second_record.id)
@@ -454,7 +450,6 @@ async def test_bulk_update_manually_selected_records_replaces_related_records(
             session,
             clear_relations,
             [identifiers.SurveyRelatedRecordId(second_record.id)],
-            identifiers.UserId(admin_user.id),
         )
         related_to = await record_queries.list_survey_related_record_related_to_records(
             session, identifiers.SurveyRelatedRecordId(second_record.id)

--- a/tests/test_operations_surveyrelatedrecords.py
+++ b/tests/test_operations_surveyrelatedrecords.py
@@ -2,7 +2,6 @@ import uuid
 
 import pytest
 
-from seis_lab_data import constants
 from seis_lab_data.operations import surveyrelatedrecords as record_ops
 from seis_lab_data.schemas import (
     identifiers,
@@ -45,74 +44,6 @@ async def test_bulk_update_denies_user_without_editor_role(
     assert result is None
     assert len(dispatcher.events) == 1
     assert dispatcher.events[0].succeeded is False
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_bulk_update_restricts_non_admin_editor_to_owned_records(
-    db,
-    db_session_maker,
-    sample_survey_related_records,
-    bootstrap_workflow_stages,
-):
-    # this editor owns none of the sample records/missions/projects
-    other_editor = User(
-        id=UserId("other-editor"),
-        username="other-editor",
-        email="other-editor@tests.dev",
-        roles=[constants.ROLE_EDITOR],
-    )
-    new_stage = [
-        w for w in bootstrap_workflow_stages if w.name["en"] == "quality control data"
-    ][0]
-    to_update = record_schemas.SurveyRelatedRecordBulkUpdate(
-        workflow_stage_id=identifiers.WorkflowStageId(new_stage.id)
-    )
-    dispatcher = _EventCollector()
-    async with db_session_maker() as session:
-        result = await record_ops.bulk_update_survey_related_records(
-            request_id=RequestId(uuid.uuid4()),
-            to_update=to_update,
-            initiator=other_editor,
-            session=session,
-            event_dispatcher=dispatcher,
-            en_name_filter="First",
-        )
-    assert result == 0
-    assert len(dispatcher.events) == 1
-    assert dispatcher.events[0].succeeded is True
-    assert dispatcher.events[0].affected_count == 0
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_bulk_update_admin_bypasses_ownership_restriction(
-    db,
-    db_session_maker,
-    sample_survey_related_records,
-    bootstrap_workflow_stages,
-    admin_user,
-):
-    first_record, second_record = sample_survey_related_records
-    new_stage = [
-        w for w in bootstrap_workflow_stages if w.name["en"] == "quality control data"
-    ][0]
-    to_update = record_schemas.SurveyRelatedRecordBulkUpdate(
-        workflow_stage_id=identifiers.WorkflowStageId(new_stage.id)
-    )
-    dispatcher = _EventCollector()
-    async with db_session_maker() as session:
-        result = await record_ops.bulk_update_survey_related_records(
-            request_id=RequestId(uuid.uuid4()),
-            to_update=to_update,
-            initiator=admin_user,
-            session=session,
-            event_dispatcher=dispatcher,
-            en_name_filter="First",
-        )
-    assert result == 1
-    assert dispatcher.events[0].succeeded is True
-    assert dispatcher.events[0].affected_count == 1
 
 
 @pytest.mark.integration


### PR DESCRIPTION
This PR simplifies access controls by implementing the refactored discussed in #166. Note that the removal of the `owner_id` columns described in #181 is not done in this PR and still needs to be done

---

- fixes #166