### PR TITLE
Adds icons to breadcrumbs and some colors

### DIFF
--- a/src/seis_lab_data/webapp/routes/datasetcategories.py
+++ b/src/seis_lab_data/webapp/routes/datasetcategories.py
@@ -352,6 +352,7 @@ class DatasetCategoryCollectionEndpoint(HTTPEndpoint):
                     webui_schemas.BreadcrumbItem(
                         name=_("Home"),
                         url=request.url_for("home"),
+                        icon=settings.icons.home,
                     ),
                     webui_schemas.BreadcrumbItem(
                         name=_("Dataset categories"),

--- a/src/seis_lab_data/webapp/routes/discovery.py
+++ b/src/seis_lab_data/webapp/routes/discovery.py
@@ -370,6 +370,7 @@ class AssetDiscoveryConfigurationCollectionEndpoint(HTTPEndpoint):
                 "breadcrumbs": [
                     webui_schemas.BreadcrumbItem(
                         name=_("Home"),
+                        icon=settings.icons.home,
                         url=request.url_for("home"),
                     ),
                     webui_schemas.BreadcrumbItem(

--- a/src/seis_lab_data/webapp/routes/projects.py
+++ b/src/seis_lab_data/webapp/routes/projects.py
@@ -70,6 +70,7 @@ async def get_project_creation_form(request: Request):
     form_instance = await project_forms.ProjectCreateForm.from_formdata(request)
     form_instance.request_id.data = str(identifiers.RequestId(uuid.uuid4()))
     template_processor: Jinja2Templates = request.state.templates
+    settings: config.SeisLabDataSettings = request.state.settings
     return template_processor.TemplateResponse(
         request,
         "projects/create-form-page.html",
@@ -77,12 +78,18 @@ async def get_project_creation_form(request: Request):
             "form": form_instance,
             "breadcrumbs": [
                 webui_schemas.BreadcrumbItem(
-                    name=_("Home"), url=request.url_for("home")
+                    name=_("Home"),
+                    url=request.url_for("home"),
+                    icon=settings.icons.home,
                 ),
                 webui_schemas.BreadcrumbItem(
-                    name=_("Projects"), url=request.url_for("projects:list")
+                    name=_("Projects"),
+                    url=request.url_for("projects:list"),
+                    icon=settings.icons.projects,
                 ),
-                webui_schemas.BreadcrumbItem(name=_("New project")),
+                webui_schemas.BreadcrumbItem(
+                    name=_("New project"), icon=settings.icons.new_item
+                ),
             ],
         },
     )
@@ -156,6 +163,7 @@ async def get_project_update_form(request: Request):
     )
     update_form.request_id.data = uuid.uuid4()
     template_processor: Jinja2Templates = request.state.templates
+    settings: config.SeisLabDataSettings = request.state.settings
     return template_processor.TemplateResponse(
         request,
         "projects/update-form-page.html",
@@ -164,16 +172,23 @@ async def get_project_update_form(request: Request):
             "form": update_form,
             "breadcrumbs": [
                 webui_schemas.BreadcrumbItem(
-                    name=_("Home"), url=request.url_for("home")
+                    name=_("Home"),
+                    url=request.url_for("home"),
+                    icon=settings.icons.home,
                 ),
                 webui_schemas.BreadcrumbItem(
-                    name=_("Projects"), url=request.url_for("projects:list")
+                    name=_("Projects"),
+                    url=request.url_for("projects:list"),
+                    icon=settings.icons.projects,
                 ),
                 webui_schemas.BreadcrumbItem(
                     name=project.name["en"],
                     url=request.url_for("projects:detail", project_id=project_id),
+                    icon=settings.icons.projects,
                 ),
-                webui_schemas.BreadcrumbItem(name=_("Edit project")),
+                webui_schemas.BreadcrumbItem(
+                    name=_("Edit"), icon=settings.icons.edit_item
+                ),
             ],
         },
     )
@@ -418,13 +433,13 @@ async def _get_project_details(request: Request) -> webui_schemas.ProjectDetails
         breadcrumbs=[
             webui_schemas.BreadcrumbItem(
                 name=_("Home"),
-                # icon=settings.icons.home,
                 url=str(request.url_for("home")),
+                icon=settings.icons.home,
             ),
             webui_schemas.BreadcrumbItem(
                 name=_("Projects"),
-                # icon=settings.icons.list,
                 url=request.url_for("projects:list"),
+                icon=settings.icons.projects,
             ),
             webui_schemas.BreadcrumbItem(
                 name=project.name["en"],
@@ -564,7 +579,7 @@ class ProjectCollectionEndpoint(HTTPEndpoint):
                 "breadcrumbs": [
                     webui_schemas.BreadcrumbItem(
                         name=_("Home"),
-                        # icon=settings.icons.home,
+                        icon=settings.icons.home,
                         url=request.url_for("home"),
                     ),
                     webui_schemas.BreadcrumbItem(

--- a/src/seis_lab_data/webapp/routes/surveymissions.py
+++ b/src/seis_lab_data/webapp/routes/surveymissions.py
@@ -187,10 +187,14 @@ async def _get_survey_mission_details(
         ),
         breadcrumbs=[
             webui_schemas.BreadcrumbItem(
-                name=_("Home"), url=str(request.url_for("home"))
+                name=_("Home"),
+                url=str(request.url_for("home")),
+                icon=settings.icons.home,
             ),
             webui_schemas.BreadcrumbItem(
-                name=_("Projects"), url=str(request.url_for("projects:list"))
+                name=_("Projects"),
+                url=str(request.url_for("projects:list")),
+                icon=settings.icons.projects,
             ),
             webui_schemas.BreadcrumbItem(
                 name=str(survey_mission.project.name["en"]),
@@ -200,9 +204,10 @@ async def _get_survey_mission_details(
                         project_id=survey_mission.project.id,
                     )
                 ),
+                icon=settings.icons.projects,
             ),
             webui_schemas.BreadcrumbItem(
-                name=str(survey_mission.name["en"]),
+                name=str(survey_mission.name["en"]), icon=settings.icons.survey_missions
             ),
         ],
     )
@@ -342,6 +347,7 @@ async def get_survey_mission_creation_form(request: Request):
             )
 
     template_processor: Jinja2Templates = request.state.templates
+    settings: config.SeisLabDataSettings = request.state.settings
     return template_processor.TemplateResponse(
         request,
         "survey-missions/create-form-page.html",
@@ -350,16 +356,23 @@ async def get_survey_mission_creation_form(request: Request):
             "form": form_instance,
             "breadcrumbs": [
                 webui_schemas.BreadcrumbItem(
-                    name=_("Home"), url=request.url_for("home")
+                    name=_("Home"),
+                    url=request.url_for("home"),
+                    icon=settings.icons.home,
                 ),
                 webui_schemas.BreadcrumbItem(
-                    name=_("Projects"), url=request.url_for("projects:list")
+                    name=_("Projects"),
+                    url=request.url_for("projects:list"),
+                    icon=settings.icons.projects,
                 ),
                 webui_schemas.BreadcrumbItem(
                     name=project.name["en"],
                     url=request.url_for("projects:detail", project_id=project.id),
+                    icon=settings.icons.projects,
                 ),
-                webui_schemas.BreadcrumbItem(name=_("New survey mission")),
+                webui_schemas.BreadcrumbItem(
+                    name=_("New survey mission"), icon=settings.icons.new_item
+                ),
             ],
         },
     )
@@ -610,9 +623,13 @@ class SurveyMissionCollectionEndpoint(HTTPEndpoint):
                 },
                 "breadcrumbs": [
                     webui_schemas.BreadcrumbItem(
-                        name=_("Home"), url=request.url_for("home")
+                        name=_("Home"),
+                        url=request.url_for("home"),
+                        icon=settings.icons.home,
                     ),
-                    webui_schemas.BreadcrumbItem(name=_("Survey Missions")),
+                    webui_schemas.BreadcrumbItem(
+                        name=_("Survey Missions"), icon=settings.icons.survey_missions
+                    ),
                 ],
                 "search_initial_value": list_filters.get_text_search_filter(
                     current_language
@@ -1099,6 +1116,7 @@ async def get_survey_mission_update_form(request: Request):
     )
     update_form.request_id.data = uuid.uuid4()
     template_processor: Jinja2Templates = request.state.templates
+    settings: config.SeisLabDataSettings = request.state.settings
     return template_processor.TemplateResponse(
         request,
         "survey-missions/update-form-page.html",
@@ -1107,19 +1125,32 @@ async def get_survey_mission_update_form(request: Request):
             "form": update_form,
             "breadcrumbs": [
                 webui_schemas.BreadcrumbItem(
-                    name=_("Home"), url=request.url_for("home")
+                    name=_("Home"),
+                    url=request.url_for("home"),
+                    icon=settings.icons.home,
                 ),
                 webui_schemas.BreadcrumbItem(
-                    name=_("Survey missions"),
-                    url=request.url_for("survey_missions:list"),
+                    name=_("Projects"),
+                    url=request.url_for("projects:list"),
+                    icon=settings.icons.projects,
+                ),
+                webui_schemas.BreadcrumbItem(
+                    name=survey_mission.project.name["en"],
+                    url=request.url_for(
+                        "projects:detail", project_id=survey_mission.project_id
+                    ),
+                    icon=settings.icons.projects,
                 ),
                 webui_schemas.BreadcrumbItem(
                     name=survey_mission.name["en"],
                     url=request.url_for(
                         "survey_missions:detail", survey_mission_id=survey_mission_id
                     ),
+                    icon=settings.icons.survey_missions,
                 ),
-                webui_schemas.BreadcrumbItem(name=_("Edit survey mission")),
+                webui_schemas.BreadcrumbItem(
+                    name=_("Edit"), icon=settings.icons.edit_item
+                ),
             ],
         },
     )

--- a/src/seis_lab_data/webapp/routes/surveyrelatedrecords.py
+++ b/src/seis_lab_data/webapp/routes/surveyrelatedrecords.py
@@ -102,6 +102,7 @@ async def _get_survey_related_record_details(
     can_update = record_permissions.can_update_survey_related_record(
         user, survey_related_record
     )
+    settings: config.SeisLabDataSettings = request.state.settings
     return webui_schemas.SurveyRelatedRecordDetails(
         item=serialized,
         permissions=webui_schemas.UserPermissionDetails(
@@ -113,10 +114,14 @@ async def _get_survey_related_record_details(
         ),
         breadcrumbs=[
             webui_schemas.BreadcrumbItem(
-                name=_("Home"), url=str(request.url_for("home"))
+                name=_("Home"),
+                url=str(request.url_for("home")),
+                icon=settings.icons.home,
             ),
             webui_schemas.BreadcrumbItem(
-                name=_("Projects"), url=str(request.url_for("projects:list"))
+                name=_("Projects"),
+                url=str(request.url_for("projects:list")),
+                icon=settings.icons.projects,
             ),
             webui_schemas.BreadcrumbItem(
                 name=str(survey_related_record.survey_mission.project.name["en"]),
@@ -126,6 +131,7 @@ async def _get_survey_related_record_details(
                         project_id=survey_related_record.survey_mission.project.id,
                     )
                 ),
+                icon=settings.icons.projects,
             ),
             webui_schemas.BreadcrumbItem(
                 name=str(survey_related_record.survey_mission.name["en"]),
@@ -135,9 +141,11 @@ async def _get_survey_related_record_details(
                         survey_mission_id=survey_related_record.survey_mission.id,
                     )
                 ),
+                icon=settings.icons.survey_missions,
             ),
             webui_schemas.BreadcrumbItem(
                 name=str(survey_related_record.name["en"]),
+                icon=settings.icons.survey_related_records,
             ),
         ],
     )
@@ -223,6 +231,7 @@ async def get_creation_form(request: Request):
     form_instance = await forms.SurveyRelatedRecordCreateForm.from_request(request)
     form_instance.request_id.data = str(identifiers.RequestId(uuid.uuid4()))
     template_processor: Jinja2Templates = request.state.templates
+    settings: config.SeisLabDataSettings = request.state.settings
     return template_processor.TemplateResponse(
         request,
         "survey-related-records/create-form-page.html",
@@ -231,24 +240,32 @@ async def get_creation_form(request: Request):
             "survey_mission_id": survey_mission_id,
             "breadcrumbs": [
                 webui_schemas.BreadcrumbItem(
-                    name=_("Home"), url=request.url_for("home")
+                    name=_("Home"),
+                    url=request.url_for("home"),
+                    icon=settings.icons.home,
                 ),
                 webui_schemas.BreadcrumbItem(
-                    name=_("Projects"), url=request.url_for("projects:list")
+                    name=_("Projects"),
+                    url=request.url_for("projects:list"),
+                    icon=settings.icons.projects,
                 ),
                 webui_schemas.BreadcrumbItem(
                     name=parent_survey_mission.project.name["en"],
                     url=request.url_for(
                         "projects:detail", project_id=parent_survey_mission.project.id
                     ),
+                    icon=settings.icons.projects,
                 ),
                 webui_schemas.BreadcrumbItem(
                     name=parent_survey_mission.name["en"],
                     url=request.url_for(
                         "survey_missions:detail", survey_mission_id=survey_mission_id
                     ),
+                    icon=settings.icons.survey_missions,
                 ),
-                webui_schemas.BreadcrumbItem(name=_("New survey-related record")),
+                webui_schemas.BreadcrumbItem(
+                    name=_("New survey-related record"), icon=settings.icons.new_item
+                ),
             ],
         },
     )
@@ -576,6 +593,7 @@ async def get_update_form(request: Request):
     initial_related_records = [
         (i.id, i.name["en"]) for i in initial_related_records_list
     ]
+    settings: config.SeisLabDataSettings = request.state.settings
     return template_processor.TemplateResponse(
         request,
         "survey-related-records/update-form-page.html",
@@ -585,11 +603,30 @@ async def get_update_form(request: Request):
             "initial_related_records": initial_related_records,
             "breadcrumbs": [
                 webui_schemas.BreadcrumbItem(
-                    name=_("Home"), url=request.url_for("home")
+                    name=_("Home"),
+                    url=request.url_for("home"),
+                    icon=settings.icons.home,
                 ),
                 webui_schemas.BreadcrumbItem(
-                    name=_("Survey-related records"),
-                    url=request.url_for("survey_related_records:list"),
+                    name=_("Projects"),
+                    url=request.url_for("projects:list"),
+                    icon=settings.icons.projects,
+                ),
+                webui_schemas.BreadcrumbItem(
+                    name=details.item.survey_mission.project.name.en,
+                    url=request.url_for(
+                        "projects:detail",
+                        project_id=details.item.survey_mission.project.id,
+                    ),
+                    icon=settings.icons.projects,
+                ),
+                webui_schemas.BreadcrumbItem(
+                    name=details.item.survey_mission.name.en,
+                    url=request.url_for(
+                        "survey_missions:detail",
+                        survey_mission_id=details.item.survey_mission.id,
+                    ),
+                    icon=settings.icons.survey_missions,
                 ),
                 webui_schemas.BreadcrumbItem(
                     name=details.item.name.en,
@@ -597,8 +634,11 @@ async def get_update_form(request: Request):
                         "survey_related_records:detail",
                         survey_related_record_id=details.item.id,
                     ),
+                    icon=settings.icons.survey_related_records,
                 ),
-                webui_schemas.BreadcrumbItem(name=_("Edit survey-related record")),
+                webui_schemas.BreadcrumbItem(
+                    name=_("Edit"), icon=settings.icons.edit_item
+                ),
             ],
         },
     )
@@ -1110,9 +1150,14 @@ class SurveyRelatedRecordCollectionEndpoint(HTTPEndpoint):
                 },
                 "breadcrumbs": [
                     webui_schemas.BreadcrumbItem(
-                        name=_("Home"), url=request.url_for("home")
+                        name=_("Home"),
+                        url=request.url_for("home"),
+                        icon=settings.icons.home,
                     ),
-                    webui_schemas.BreadcrumbItem(name=_("Survey-related records")),
+                    webui_schemas.BreadcrumbItem(
+                        name=_("Survey-related records"),
+                        icon=settings.icons.survey_related_records,
+                    ),
                 ],
                 "search_initial_value": list_filters.get_text_search_filter(
                     current_language

--- a/src/seis_lab_data/webapp/routes/workflowstages.py
+++ b/src/seis_lab_data/webapp/routes/workflowstages.py
@@ -344,6 +344,7 @@ class WorkflowStageCollectionEndpoint(HTTPEndpoint):
                 "breadcrumbs": [
                     webui_schemas.BreadcrumbItem(
                         name=_("Home"),
+                        icon=settings.icons.home,
                         url=request.url_for("home"),
                     ),
                     webui_schemas.BreadcrumbItem(

--- a/src/seis_lab_data/webapp/static/css/custom.css
+++ b/src/seis_lab_data/webapp/static/css/custom.css
@@ -1,6 +1,12 @@
 :root {
     --bs-dataset-category-color: #ff6b35;
     --bs-workflow-stage-color: #a83604;
+    --bs-project-color: #c77dff;
+    --bs-survey-mission-color: #b8f24a;
+    --bs-survey-related-record-color: #f9a8d4;
+    --bs-project-color-dark: #7b2cbf;
+    --bs-survey-mission-color-dark: #486b00;
+    --bs-survey-related-record-color-dark: #be185d;
 }
 
 .bg-dataset-category {
@@ -17,6 +23,52 @@
 
 .text-workflow-stage {
     color: var(--bs-workflow-stage-color) !important;
+}
+
+.bg-project {
+    background-color: var(--bs-project-color) !important;
+}
+
+.bg-survey-mission {
+    background-color: var(--bs-survey-mission-color) !important;
+}
+
+.bg-survey-related-record {
+    background-color: var(--bs-survey-related-record-color) !important;
+}
+
+.resource-type-bar {
+    height: 32px;
+}
+
+.nav-link-project:hover,
+.nav-link-project:focus,
+.nav-link-project.active {
+    color: var(--bs-project-color) !important;
+}
+
+.nav-link-survey-mission:hover,
+.nav-link-survey-mission:focus,
+.nav-link-survey-mission.active {
+    color: var(--bs-survey-mission-color) !important;
+}
+
+.nav-link-survey-related-record:hover,
+.nav-link-survey-related-record:focus,
+.nav-link-survey-related-record.active {
+    color: var(--bs-survey-related-record-color) !important;
+}
+
+.title-project {
+    color: var(--bs-project-color-dark) !important;
+}
+
+.title-survey-mission {
+    color: var(--bs-survey-mission-color-dark) !important;
+}
+
+.title-survey-related-record {
+    color: var(--bs-survey-related-record-color-dark) !important;
 }
 
 @view-transition {

--- a/src/seis_lab_data/webapp/templates/base.html
+++ b/src/seis_lab_data/webapp/templates/base.html
@@ -13,7 +13,8 @@
     {% endblock %}
 </head>
 <body>
-<header class="mb-3 border-bottom bg-primary">
+{% set resource_type_class = self.resource_type_color_class() %}
+<header class="border-bottom bg-primary">
     <nav class="navbar navbar-expand-lg" data-bs-theme="dark">
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center gap-2" href="{{ url_for('home') }}">
@@ -34,17 +35,17 @@
             <div class="collapse navbar-collapse" id="main-navbar">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0 ms-lg-4 gap-lg-2">
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('projects:list') }}" aria-label="list-projects" title="{{ _('Projects') }}">
+                        <a class="nav-link nav-link-project{% if resource_type_class == 'bg-project' %} active{% endif %}" href="{{ url_for('projects:list') }}" aria-label="list-projects" title="{{ _('Projects') }}" {% if resource_type_class == 'bg-project' %}aria-current="page"{% endif %}>
                             <span class="material-icons-outlined" aria-hidden="true">{{ icons.projects }}</span>{{ _("Projects") }}
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('survey_missions:list') }}" aria-label="list-survey-missions" title="{{ _('Survey Missions') }}">
+                        <a class="nav-link nav-link-survey-mission{% if resource_type_class == 'bg-survey-mission' %} active{% endif %}" href="{{ url_for('survey_missions:list') }}" aria-label="list-survey-missions" title="{{ _('Survey Missions') }}" {% if resource_type_class == 'bg-survey-mission' %}aria-current="page"{% endif %}>
                             <span class="material-icons-outlined" aria-hidden="true">{{ icons.survey_missions }}</span>{{ _("Survey Missions") }}
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('survey_related_records:list') }}" aria-label="list-survey-related-records" title="{{ _('Survey-related Records') }}">
+                        <a class="nav-link nav-link-survey-related-record{% if resource_type_class == 'bg-survey-related-record' %} active{% endif %}" href="{{ url_for('survey_related_records:list') }}" aria-label="list-survey-related-records" title="{{ _('Survey-related Records') }}" {% if resource_type_class == 'bg-survey-related-record' %}aria-current="page"{% endif %}>
                             <span class="material-icons-outlined" aria-hidden="true">{{ icons.survey_related_records }}</span>{{ _("Survey-related Records") }}
                         </a>
                     </li>
@@ -157,16 +158,17 @@
             </div>
         </div>
     </nav>
+    <div class="resource-type-bar {% block resource_type_color_class %}{% endblock %}" aria-hidden="true"></div>
 </header>
+{% if breadcrumbs %}
+    {% include 'breadcrumbs.html' %}
+{% endif %}
 <div class="container-fluid">
-    {% if breadcrumbs %}
-        {% include 'breadcrumbs.html' %}
-    {% endif %}
     <div class="row m-5">
         <div class="col">
             {% block content %}
                 {% block header %}
-                    <h1 class="display-1" aria-label="title">{% block page_title %}{% endblock page_title %}</h1>
+                    <h1 class="display-1 text-truncate {% block header_extra_class %}{% endblock %}{% if resource_type_class == 'bg-project' %} title-project{% elif resource_type_class == 'bg-survey-mission' %} title-survey-mission{% elif resource_type_class == 'bg-survey-related-record' %} title-survey-related-record{% endif %}" aria-label="title">{% block page_title %}{% endblock page_title %}</h1>
                 {% endblock %}
 
                 <div aria-label="content">

--- a/src/seis_lab_data/webapp/templates/breadcrumbs.html
+++ b/src/seis_lab_data/webapp/templates/breadcrumbs.html
@@ -1,23 +1,21 @@
-<div class="row">
-    <nav aria-label="breadcrumbs">
-        <ul class="breadcrumb p-3 bg-body-tertiary rounded-3">
-            {% for item in breadcrumbs %}
-                <li class="breadcrumb-item">
-                    {% if item.url %}
-                        <a href="{{ item.url }}">
-                            {% if item.icon %}
-                                <span class="material-icons-outlined fs-6 me-1" aria-hidden="true">{{ item.icon }}</span>
-                            {% endif %}
-                            {{ item.name }}
-                        </a>
-                    {% else %}
+<nav aria-label="breadcrumbs">
+    <ul class="breadcrumb py-3 px-3 mb-0 bg-body-tertiary rounded-0">
+        {% for item in breadcrumbs %}
+            <li class="breadcrumb-item">
+                {% if item.url %}
+                    <a href="{{ item.url }}">
                         {% if item.icon %}
                             <span class="material-icons-outlined fs-6 me-1" aria-hidden="true">{{ item.icon }}</span>
                         {% endif %}
                         {{ item.name }}
+                    </a>
+                {% else %}
+                    {% if item.icon %}
+                        <span class="material-icons-outlined fs-6 me-1" aria-hidden="true">{{ item.icon }}</span>
                     {% endif %}
-                </li>
-            {% endfor %}
-        </ul>
-    </nav>
-</div>
+                    {{ item.name }}
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+</nav>

--- a/src/seis_lab_data/webapp/templates/datasetcategories/list.html
+++ b/src/seis_lab_data/webapp/templates/datasetcategories/list.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 
+{% block header_extra_class %}text-center{% endblock %}
+
 {% block page_title %}
     <span class="icon-stack" aria-hidden="true">
         <span class="material-icons-outlined">{{ icons.dataset_category }}</span>

--- a/src/seis_lab_data/webapp/templates/discovery/list.html
+++ b/src/seis_lab_data/webapp/templates/discovery/list.html
@@ -6,6 +6,8 @@ Users with create permission are linked to /asset-discovery-configurations/new, 
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 
+{% block header_extra_class %}text-center{% endblock %}
+
 {% block page_title %}
     <span class="icon-stack" aria-hidden="true">
         <span class="material-icons-outlined">{{ icons.asset_discovery_configuration }}</span>

--- a/src/seis_lab_data/webapp/templates/projects/detail.html
+++ b/src/seis_lab_data/webapp/templates/projects/detail.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block resource_type_color_class %}bg-project{% endblock %}
+
 {% block head %}
     {{ super() }}
     <script type="module" src="{{ url_for('static', path='/js/maplibre-gl-v5.9.0.js') }}"></script>

--- a/src/seis_lab_data/webapp/templates/projects/list.html
+++ b/src/seis_lab_data/webapp/templates/projects/list.html
@@ -6,6 +6,8 @@ Users with create permission are linked to /projects/new, which is a separate st
 {% import "macros.html" as macros %}
 {% from "macros/checkbox.html" import search_checkbox  %}
 
+{% block resource_type_color_class %}bg-project{% endblock %}
+
 {% block head %}
     {{ super() }}
     <script type="module" src="{{ url_for('static', path='/js/maplibre-gl-v5.9.0.js') }}"></script>
@@ -19,7 +21,7 @@ Users with create permission are linked to /projects/new, which is a separate st
 {% endblock head %}
 
 {% block header %}
-    <h1 class="display-1 text-center" aria-label="title">
+    <h1 class="display-1 text-center title-project" aria-label="title">
         <span class="icon-stack" aria-hidden="true">
         <span class="material-icons-outlined">{{ icons.projects }}</span>
         <span class="material-icons-outlined icon-stack-badge">{{ icons.list }}</span>

--- a/src/seis_lab_data/webapp/templates/survey-missions/detail.html
+++ b/src/seis_lab_data/webapp/templates/survey-missions/detail.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block resource_type_color_class %}bg-survey-mission{% endblock %}
+
 {% block head %}
     {{ super() }}
     <script type="module" src="{{ url_for('static', path='/js/maplibre-gl-v5.9.0.js') }}"></script>

--- a/src/seis_lab_data/webapp/templates/survey-missions/list.html
+++ b/src/seis_lab_data/webapp/templates/survey-missions/list.html
@@ -2,6 +2,10 @@
 {% import "macros.html" as macros %}
 {% from "macros/checkbox.html" import search_checkbox  %}
 
+{% block resource_type_color_class %}bg-survey-mission{% endblock %}
+
+{% block header_extra_class %}text-center{% endblock %}
+
 {% block head %}
     {{ super() }}
     <script type="module" src="{{ url_for('static', path='/js/maplibre-gl-v5.9.0.js') }}"></script>

--- a/src/seis_lab_data/webapp/templates/survey-related-records/detail-component.html
+++ b/src/seis_lab_data/webapp/templates/survey-related-records/detail-component.html
@@ -25,9 +25,9 @@
                                 <p>{{ item.description | translate_localizable_string }}</p>
                                 <dl class="row">
                                     <dt class="col-sm-3">{{ _("dataset category") | capitalize }}</dt>
-                                    <dd class="col-sm-9"><span class="badge bg-dataset-category">{% if item.dataset_category %}{{ item.dataset_category.name|translate_localizable_string }}{% else %}{{ _("unknown category") }}{% endif %}</span></dd>
+                                    <dd class="col-sm-9"><span class="badge bg-dataset-category"><span class="material-icons-outlined me-1 fs-6">{{ icons.dataset_category }}</span>{% if item.dataset_category %}{{ item.dataset_category.name|translate_localizable_string }}{% else %}{{ _("unknown category") }}{% endif %}</span></dd>
                                     <dt class="col-sm-3">{{ _("workflow stage") | capitalize }}</dt>
-                                    <dd class="col-sm-9"><span class="badge bg-workflow-stage">{% if item.workflow_stage %}{{ item.workflow_stage.name|translate_localizable_string }}{% else %}{{ _("unknown stage") }}{% endif %}</span></dd>
+                                    <dd class="col-sm-9"><span class="badge bg-workflow-stage"><span class="material-icons-outlined me-1 fs-6">{{ icons.workflow_stage }}</span>{% if item.workflow_stage %}{{ item.workflow_stage.name|translate_localizable_string }}{% else %}{{ _("unknown stage") }}{% endif %}</span></dd>
                                     <dt class="col-sm-3">{{ _("survey mission") | capitalize }}</dt>
                                     <dd class="col-sm-9">
                                         <a

--- a/src/seis_lab_data/webapp/templates/survey-related-records/detail.html
+++ b/src/seis_lab_data/webapp/templates/survey-related-records/detail.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block resource_type_color_class %}bg-survey-related-record{% endblock %}
+
 {% block head %}
     {{ super() }}
     <script type="module" src="{{ url_for('static', path='/js/maplibre-gl-v5.9.0.js') }}"></script>

--- a/src/seis_lab_data/webapp/templates/survey-related-records/list-item.html
+++ b/src/seis_lab_data/webapp/templates/survey-related-records/list-item.html
@@ -20,11 +20,11 @@
             </div>
             <div class="col-md-9">
                 <div class="card-body">
+                    <h5 class="card-title">{{ item.name|translate_localizable_string|default(_("name not available"), True) }}</h5>
                     <div class="row justify-content-between">
                         <div class="d-flex align-items-center flex-wrap gap-2">
-                            <h5 class="card-title mb-0">{{ item.name|translate_localizable_string|default(_("name not available"), True) }}</h5>
-                            <span class="badge bg-dataset-category">{% if item.dataset_category %}{{ item.dataset_category.name | translate_localizable_string }}{% else %}{{ _("unknown category") }}{% endif %}</span>
-                            <span class="badge bg-workflow-stage">{% if item.workflow_stage %}{{ item.workflow_stage.name | translate_localizable_string }}{% else %}{{ _("unknown stage") }}{% endif %}</span>
+                            <span class="badge bg-dataset-category"><span class="material-icons-outlined me-1 fs-6">{{ icons.dataset_category }}</span>{% if item.dataset_category %}{{ item.dataset_category.name | translate_localizable_string }}{% else %}{{ _("unknown category") }}{% endif %}</span>
+                            <span class="badge bg-workflow-stage"><span class="material-icons-outlined me-1 fs-6">{{ icons.workflow_stage }}</span>{% if item.workflow_stage %}{{ item.workflow_stage.name | translate_localizable_string }}{% else %}{{ _("unknown stage") }}{% endif %}</span>
                         </div>
                         <div class="card-text my-2">
                             <span class="material-icons-outlined me-1">{{ icons.projects }}</span>

--- a/src/seis_lab_data/webapp/templates/survey-related-records/list.html
+++ b/src/seis_lab_data/webapp/templates/survey-related-records/list.html
@@ -4,6 +4,10 @@
 {% from "macros/select.html" import search_select %}
 {% from "macros/datalist.html" import search_datalist %}
 
+{% block resource_type_color_class %}bg-survey-related-record{% endblock %}
+
+{% block header_extra_class %}text-center{% endblock %}
+
 {% block head %}
     {{ super() }}
     <script type="module" src="{{ url_for('static', path='/js/maplibre-gl-v5.9.0.js') }}"></script>

--- a/src/seis_lab_data/webapp/templates/workflowstages/list.html
+++ b/src/seis_lab_data/webapp/templates/workflowstages/list.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 
+{% block header_extra_class %}text-center{% endblock %}
+
 {% block page_title %}
     <span class="icon-stack" aria-hidden="true">
         <span class="material-icons-outlined">{{ icons.workflow_stage }}</span>


### PR DESCRIPTION
This PR tightens breadcrumbs a bit by adding icons and removing some extra spacing around them. It also adds a color bar and some custom per-item-type colors - it is hoped that this provides guidance for the user in order to better navigate the UI.

---

- fixes #95 
- fixes #158 